### PR TITLE
Create log event parser and event handlers

### DIFF
--- a/git-keeper-core/gkeepcore/event_handler.py
+++ b/git-keeper-core/gkeepcore/event_handler.py
@@ -1,0 +1,67 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import abc
+
+
+class HandlerException(Exception):
+    pass
+
+
+class EventHandler(metaclass=abc.ABCMeta):
+    """Base class for objects which handle logged events.
+
+    The constructor takes in the information from the log and calls _parse().
+
+    It is the responsibility of classes which inherit from EventHandler to
+    implement _parse() and handle().
+
+    _parse() should simply extract any needed information from the log data and
+    store the iformation in private attributes. If there are any syntax errors
+    in the log information it must raise a HandlerException. It should verify
+    syntax but it should *not* verify that the information is valid.
+
+    handle() should verify that the information is valid and then do what is
+    necessary to handle the event.
+
+    handle() will be called in the main thread, while _parse will be called in
+    the log event parsing thread.
+
+    The event type is not a parameter for the constructor, because each event
+    type has its own EventHandler subclass.
+    """
+
+    def __init__(self, log_path: str, timestamp: int, payload: str):
+        """Store the information from the log and call _parse()
+
+        :param log_path: path to the log file that the information came from
+        :param timestamp: the time the event was logged, in seconds from the
+                          epoch
+        :param payload: the rest of the text from the logged event
+        """
+        self._log_path = log_path
+        self._timestamp = timestamp
+        self._payload = payload
+
+        self._parse()
+
+    @abc.abstractmethod
+    def _parse(self):
+        """Parse the log path and log payload"""
+
+    @abc.abstractmethod
+    def handle(self):
+        """Handle the event in an appropriate way"""

--- a/git-keeper-core/gkeepcore/log_event_parser.py
+++ b/git-keeper-core/gkeepcore/log_event_parser.py
@@ -1,0 +1,125 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Provides a thread for parsing new log events and creating handlers to
+handle them.
+"""
+
+
+import re
+from queue import Queue
+from threading import Thread
+
+from gkeepcore.event_handler import EventHandler, HandlerException
+
+
+class LogEventParserException(Exception):
+    pass
+
+
+class LogEventParserThread(Thread):
+    """Parse new log events and create handlers to handle them.
+
+    New log events arrive as (<log file path>, <log line>) tuples from a
+    queue which is passed to the constructor. The events are parsed and the
+    appropriate EventHandler object is created. The EventHandler object is
+    then placed into another queue so that the main thread can actually call
+    the handler.
+
+    Log lines look like this:
+
+        <timestamp> <event type> <payload>
+
+    <timestamp> is represented as seconds from the epoch.
+
+    <event type> determines which EventHandler will handle the event. A
+    dictionary mapping <event type> strings to EventHandler subclasses is
+    passed in to the constructor.
+
+    Call the inherited start() method to start the thread, do not call run()
+    directly.
+    """
+
+    def __init__(self, new_log_line_queue: Queue, event_handler_queue: Queue,
+                 event_handlers_by_type: dict):
+        """
+        :param new_log_line_queue: input queue. (<log file path>, <log line>)
+         tuples arrive in this queue
+        :param event_handler_queue: output queue. EventHandler objects are
+         placed in this queue after parsing
+        :param event_handlers_by_type: dictionary mapping event type strings
+         to EventHandler subclases
+        """
+
+        Thread.__init__(self)
+
+        self._event_handlers_by_type = event_handlers_by_type
+        self._new_log_line_queue = new_log_line_queue
+        self._event_handler_queue = event_handler_queue
+
+    def run(self):
+        """Continually get new log lines from the input queue, parse them,
+        and place the appropriate EventHandler object in the output queue.
+
+        Do not call this method directly. Call start() instead.
+        """
+        while True:
+            log_path, log_line = self._new_log_line_queue.get()
+
+            try:
+                handler = self._parse_event(log_path, log_line)
+                self._event_handler_queue.put(handler)
+            except LogEventParserException:
+                # FIXME - log this
+                pass
+            except HandlerException:
+                # FIXME - log this
+                pass
+
+    def _parse_event(self, log_path, log_line) -> EventHandler:
+        # Parse the event. This is done in two stages:
+        #
+        # - Timestamp, event type, and payload are extracted from the log line
+        # - An EventHandler is created, which parses the rest of the event
+        #
+        # Raises:
+        #     LogEventParserException
+        #     HandlerException
+        #
+        # :param log_path: the path to the log file
+        # :param log_line: the line from the log file representing the event
+        # :return: an EventHandler object which will handle the event
+
+        # use a regular expression to match timestamp, event type, and payload
+        match = re.match('(\d+) (\w+) (.*)', log_line)
+
+        if match is None:
+            error = 'Log line does not look like an event'
+            raise LogEventParserException(error)
+
+        timestamp, event_type, payload = match.groups()
+
+        # raise exception on unknown event type
+        if event_type not in self._event_handlers_by_type:
+            raise LogEventParserException('No handler for event type {0}'
+                                          .format(event_type))
+
+        # get the handler class from the dictionary
+        handler_class = self._event_handlers_by_type[event_type]
+        # construct the handler from whatever class was selected
+        handler = handler_class(log_path, int(timestamp), payload)
+
+        return handler

--- a/git-keeper-core/gkeepcore/path_utils.py
+++ b/git-keeper-core/gkeepcore/path_utils.py
@@ -1,0 +1,123 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Utility functions for extracting information from paths."""
+
+
+import os
+
+
+def path_to_list(path: str) -> list:
+    """Constructs a list containing each element of a path.
+
+    Example:
+
+      /an/example/path -> ['an', 'example', 'path']
+
+    :param path: the path to convert
+    :return: a list containing each path element
+    """
+
+    elements = []
+
+    # remove any slashes from the beginning and the end of the path
+    path = path.strip('/')
+
+    # continually split the path, which splits the last element in the path
+    # from the rest
+    while path != '':
+        path, basename = os.path.split(path)
+        elements.insert(0, basename)
+
+    return elements
+
+
+def parse_user_log_path(path: str) -> str:
+    """Extracts the username from a faculty or student log file.
+
+    :param path: path of the log file
+    :return: the username or None if the path is malformed
+    """
+
+    # we're parsing a path that ends with this:
+    # <username>/git-keeper-<username>.log
+
+    path_list = path_to_list(path)
+
+    if len(path_list) < 2:
+        return None
+
+    # the information we want is in the last 2 elements of the list
+    username, log_filename = path_list[-2:]
+
+    expected_filename = 'git-keeper-' + username + '.log'
+
+    if log_filename != expected_filename:
+        return None
+
+    return username
+
+
+def parse_submission_repo_path(path) -> (str, str, str):
+    """Extracts the faculty username, the class name, and the assignment name
+    from a student's submission repository.
+
+    :param path: path to the submission repository
+    :return: a tuple containing the faculty username, the class name, and the
+             assignment name, or None if the path is malformed
+    """
+
+    # we're parsing a path which ends with this:
+    # <faculty>/<class>/<assignment>.git
+
+    path_list = path_to_list(path)
+
+    if len(path_list) < 3:
+        return None
+
+    # the information we want is in the last 3 elements of the list
+    faculty_username, class_name, repo_name = path_list[-3:]
+
+    # repo name must end with .git and must be more than just .git
+    if not repo_name.endswith('.git') or repo_name == '.git':
+        return None
+
+    # strip the last 4 characters off the repo name to get the assignment name
+    assignment_name = repo_name[:-4]
+
+    return faculty_username, class_name, assignment_name
+
+
+def parse_faculty_assignment_path(path) -> (str, str):
+    """Extracts the class name and assignment name from a path to a faculty
+    assignment directory
+    :param path: path to the assignment directory
+    :return: a tuple containing the class name and the assignment name, or
+             None if the path is malformed
+    """
+
+    # we're parsing a path that ends with this:
+    # <class>/<assignment>
+
+    path_list = path_to_list(path)
+
+    if len(path_list) < 2:
+        return None
+
+    # the information we want is in the last 2 elements of the list
+    class_name, assignment_name = path_list[-2:]
+
+    return class_name, assignment_name

--- a/git-keeper-core/tests/test_path_utils.py
+++ b/git-keeper-core/tests/test_path_utils.py
@@ -1,0 +1,44 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Tests for gkeepcore.path_utils functions."""
+
+
+from gkeepcore.path_utils import path_to_list, parse_user_log_path
+
+
+def test_path_to_list():
+    # full path to file
+    path_list = path_to_list('/home/student/git-keeper-student.log')
+    assert ['home', 'student', 'git-keeper-student.log'] == path_list
+
+    # relative path to directory
+    path_list = path_to_list('relative/directory/path/')
+    assert ['relative', 'directory', 'path'] == path_list
+
+
+def test_extract_username_from_log_path():
+    # valid student log path
+    path = '/home/student/git-keeper-student.log'
+    assert 'student' == parse_user_log_path(path)
+
+    # not a valid user log path, should return None
+    path = '/home/student/git-keeper.log'
+    assert parse_user_log_path(path) is None
+
+    # valid faculty relative path
+    path = 'faculty/git-keeper-faculty.log'
+    assert 'faculty' == parse_user_log_path(path)

--- a/git-keeper-server/gkeepserver/event_handlers/__init__.py
+++ b/git-keeper-server/gkeepserver/event_handlers/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/git-keeper-server/gkeepserver/event_handlers/handler_registry.py
+++ b/git-keeper-server/gkeepserver/event_handlers/handler_registry.py
@@ -1,0 +1,28 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Provides a dictionary which maps event type strings to event handler
+classes. Pass event_handlers_by_type to a LogEventParserThread constructor."""
+
+
+from gkeepserver.event_handlers.submission_handler import SubmissionHandler
+from gkeepserver.event_handlers.upload_handler import UploadHandler
+
+
+event_handlers_by_type = {
+    'SUBMISSION': SubmissionHandler,
+    'UPLOAD': UploadHandler
+}

--- a/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
@@ -1,0 +1,99 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Handler for student submissions
+
+Event type: SUBMISSION
+"""
+
+
+from gkeepcore.event_handler import EventHandler, HandlerException
+from gkeepcore.path_utils import parse_user_log_path, \
+    parse_submission_repo_path
+
+
+class SubmissionHandler(EventHandler):
+    """Handles a new submission from a student."""
+
+    def handle(self):
+        """Takes action after a student pushes a new submission."""
+
+        # FIXME - ensure everything exists, set things up, and run tests
+        print('Handling submission:')
+        print(' Student:   ', self._student_username)
+        print(' Faculty:   ', self._faculty_username)
+        print(' Class:     ', self._class_name)
+        print(' Assignment:', self._assignment_name)
+        print(' Repo path: ', self._submission_repo_path)
+        print()
+
+    def _parse(self):
+        """Extracts the student username, faculty username, class name,
+         assignment name, and student submission repository from the log event.
+
+        Attributes available after parsing:
+            _student_username
+            _faculty_username
+            _class_name
+            _assignment_name
+            _submission_repo_path
+        """
+
+        self._parse_log_path()
+
+        # the payload simply contains the submission repository path
+        self._submission_repo_path = self._payload
+
+        self._parse_repo_path()
+
+    def _parse_log_path(self):
+        """Extracts the student username from the log file path.
+
+        Raises:
+             HandlerException
+
+        Initializes attributes:
+            _student_username
+        """
+
+        self._student_username = parse_user_log_path(self._log_path)
+
+        if self._student_username is None:
+            raise HandlerException('Malformed log path: {0}'
+                                   .format(self._log_path))
+
+    def _parse_repo_path(self):
+        """Extracts the faculty username, class name, and assignment name from
+        the assignment path.
+
+        Raises:
+            HandlerException
+
+        Initializes attributes:
+            _faculty_username
+            _class_name
+            _assignment_name
+        """
+
+        assignment_info = \
+            parse_submission_repo_path(self._submission_repo_path)
+
+        if assignment_info is None:
+            raise HandlerException('Malformed submission repo path: {0}'
+                                   .format(self._submission_repo_path))
+
+        self._faculty_username, self._class_name, self._assignment_name = \
+            assignment_info

--- a/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
@@ -1,0 +1,93 @@
+# Copyright 2016 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Handler for new assignment uploads.
+
+Event type: UPLOAD
+"""
+
+
+from gkeepcore.event_handler import EventHandler, HandlerException
+from gkeepcore.path_utils import parse_user_log_path, \
+    parse_faculty_assignment_path
+
+
+class UploadHandler(EventHandler):
+    """Handles a new assignment uploaded by a faculty member."""
+
+    def handle(self):
+        """Takes action after a faculty member uploads a new assignment."""
+
+        # FIXME - ensure everything exists, create bare repos, email prof
+        print('Handling upload:')
+        print(' Faculty:   ', self._faculty_username)
+        print(' Class:     ', self._class_name)
+        print(' Assignment:', self._assignment_name)
+        print(' Path:      ', self._assignment_path)
+
+    def _parse(self):
+        """Extracts the faculty username, class name, assignment name, and
+        assignment path from the log event.
+
+        Attributes available after parsing:
+            _faculty_username
+            _class_name
+            _assignment_name
+            _assignment_path
+        """
+
+        self._parse_log_path()
+
+        # the log payload simply contains the assignment path
+        self._assignment_path = self._payload
+
+        self._parse_assignment_path()
+
+    def _parse_log_path(self):
+        """Extracts the faculty username from the log file path.
+
+        Raises:
+             HandlerException
+
+        Initializes attributes:
+            _faculty_username
+        """
+
+        self._faculty_username = parse_user_log_path(self._log_path)
+
+        if self._faculty_username is None:
+            raise HandlerException('Malformed log path: {0}'
+                                   .format(self._log_path))
+
+    def _parse_assignment_path(self):
+        """Extracts the class name and assignment name from the assignment
+        path.
+
+        Raises:
+            HandlerException
+
+        Initializes attributes:
+            _class_name
+            _assignment_name
+        """
+
+        assignment_info = parse_faculty_assignment_path(self._assignment_path)
+
+        if assignment_info is None:
+            raise HandlerException('Malformed assignment path: {0}'
+                                   .format(self._assignment_path))
+
+        self._class_name, self._assignment_name = assignment_info


### PR DESCRIPTION
The log event parser is complete. Only two event handlers have been
created so far: one for student submissions and one for faculty uploads.

These handlers are still stubs. They extract the necessary information
from the log but they do not yet perform the actions they will need to
perform.