### PR TITLE
Run assignment tests as a separate user

### DIFF
--- a/git-keeper-server/gkeepserver/server_configuration.py
+++ b/git-keeper-server/gkeepserver/server_configuration.py
@@ -53,6 +53,7 @@ Attributes:
 
     keeper_user - username of the user running gkeepd
     keeper_group - group name of the user running gkeepd
+    tester_user - username of the user that runs the tests
     faculty_group - group that all faculty accounts belong to
     student_group - group that all student accounts belong to
 
@@ -80,6 +81,7 @@ import os
 from getpass import getuser
 
 from gkeepcore.gkeep_exception import GkeepException
+from gkeepcore.path_utils import user_home_dir
 from gkeepserver.gkeepd_logger import LogLevel
 
 
@@ -151,15 +153,25 @@ class ServerConfiguration:
 
         self._parsed = True
 
+    @property
+    def run_action_sh_file_path(self):
+        """
+        Get the location of run_action.sh
+
+        run_action.sh is in the home directory of the tester user, so that user
+        must exist before this is called.
+
+        :return: location of run_action.sh
+        """
+
+        # path to run_action.sh
+        return os.path.join(user_home_dir(config.tester_user), 'run_action.sh')
+
     def _initialize_default_attributes(self):
         # Initialize attributes that have default values
 
         # path to .gitconfig
         self.gitconfig_file_path = os.path.join(self.home_dir, '.gitconfig')
-
-        # path to run_action.sh
-        self.run_action_sh_file_path = os.path.join(self.home_dir,
-                                                    'run_action.sh')
 
         # logging
         self.log_file_path = os.path.join(self.home_dir, 'gkeepd.log')
@@ -178,6 +190,7 @@ class ServerConfiguration:
         # users and groups
         self.keeper_user = 'keeper'
         self.keeper_group = 'keeper'
+        self.tester_user = 'tester'
         self.faculty_group = 'faculty'
         self.student_group = 'student'
 
@@ -267,6 +280,7 @@ class ServerConfiguration:
             'test_thread_count',
             'keeper_user',
             'keeper_group',
+            'tester_user',
             'faculty_group',
             'student_group'
         ]


### PR DESCRIPTION
By default the tester user is named 'tester'. This is configurable
in server.cfg via the tester_user parameter of [gkeepd].

The tester user is created automatically if it does not exist.

run_action.sh is now created in the tester user's home directory.

The keeper user must now be able to run commands as any user
(not just root) without a password using sudo.