### PR TITLE
Add caching to get_info()

### DIFF
--- a/git-keeper-client/gkeepclient/client_function_decorators.py
+++ b/git-keeper-client/gkeepclient/client_function_decorators.py
@@ -100,7 +100,8 @@ def class_exists(func):
         :param args: positional arguments to pass on to the wrapped function
         :param kwargs: keyword arguments to pass on to the original function
         """
-        if not server_interface.class_exists(class_name):
+
+        if class_name not in server_interface.get_info().class_list():
             raise GkeepException('Class {0} does not exist'.format(class_name))
 
         return func(class_name, *args, **kwargs)
@@ -129,7 +130,7 @@ def class_does_not_exist(func):
         :param args: positional arguments to pass on to the wrapped function
         :param kwargs: keyword arguments to pass on to the original function
         """
-        if server_interface.class_exists(class_name):
+        if class_name in server_interface.get_info().class_list():
             raise GkeepException('Class {0} already exists'.format(class_name))
 
         return func(class_name, *args, **kwargs)
@@ -161,7 +162,10 @@ def assignment_exists(func):
         :param args: positional arguments to pass on to the wrapped function
         :param kwargs: keyword arguments to pass on to the original function
         """
-        if not server_interface.assignment_exists(class_name, assignment_name):
+
+        assignments = server_interface.get_info().assignment_list(class_name)
+
+        if assignment_name not in assignments:
             error = ('Assignment {0} does not exist in class {1}'
                      .format(assignment_name, class_name))
             raise GkeepException(error)
@@ -195,7 +199,10 @@ def assignment_does_not_exist(func):
         :param args: positional arguments to pass on to the wrapped function
         :param kwargs: keyword arguments to pass on to the original function
         """
-        if server_interface.assignment_exists(class_name, assignment_name):
+
+        assignments = server_interface.get_info().assignment_list(class_name)
+
+        if assignment_name in assignments:
             error = ('Assignment {0} already exists in class {1}'
                      .format(assignment_name, class_name))
             raise GkeepException(error)
@@ -227,8 +234,9 @@ def assignment_published(func):
         :param args: positional arguments to pass on to the wrapped function
         :param kwargs: keyword arguments to pass on to the original function
         """
-        if not server_interface.assignment_published(class_name,
-                                                     assignment_name):
+
+        if not server_interface.get_info().is_published(class_name,
+                                                        assignment_name):
             error = ('Assignment {0} in class {1} is not published'
                      .format(assignment_name, class_name))
             raise GkeepException(error)
@@ -260,8 +268,9 @@ def assignment_not_published(func):
         :param args: positional arguments to pass on to the wrapped function
         :param kwargs: keyword arguments to pass on to the original function
         """
-        if server_interface.assignment_published(class_name,
-                                                 assignment_name):
+
+        if server_interface.get_info().is_published(class_name,
+                                                    assignment_name):
             error = ('Assignment {0} in class {1} is already published'
                      .format(assignment_name, class_name))
             raise GkeepException(error)

--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -319,6 +319,9 @@ def main():
     # Parse the args
     parsed_args = parser.parse_args()
 
+    if parsed_args.config_file is not None:
+        config.set_config_path(parsed_args.config_file)
+
     try:
         take_action(parsed_args)
     except GkeepException as e:
@@ -328,9 +331,6 @@ def main():
 @config_parsed
 def take_action(parsed_args):
     action_name = parsed_args.subparser_name
-
-    if parsed_args.config_file is not None:
-        config.set_config_path(parsed_args.config_file)
 
     # parsed_args.class_name could be an alias
     class_name = getattr(parsed_args, 'class_name', None)

--- a/git-keeper-client/gkeepclient/server_actions.py
+++ b/git-keeper-client/gkeepclient/server_actions.py
@@ -23,11 +23,9 @@ import sys
 from gkeepcore.valid_names import validate_class_name, validate_assignment_name
 
 from gkeepclient.assignment_uploader import AssignmentUploader
-from gkeepclient.client_configuration import config
 from gkeepclient.client_function_decorators import config_parsed, \
     server_interface_connected, class_does_not_exist, class_exists, \
-    assignment_exists, assignment_not_published, assignment_does_not_exist, \
-    assignment_published
+    assignment_exists, assignment_not_published, assignment_published
 from gkeepclient.server_interface import server_interface
 from gkeepclient.server_response_poller import communicate_event
 from gkeepcore.gkeep_exception import GkeepException


### PR DESCRIPTION
Function decorators which check for the existance/non-existance of
classes and assignments now use cached information from the server
rather than making a new request each time.