### PR TITLE
Handle command output that is not valid utf-8

### DIFF
--- a/git-keeper-core/gkeepcore/shell_command.py
+++ b/git-keeper-core/gkeepcore/shell_command.py
@@ -71,8 +71,9 @@ def run_command(command, sudo=False, stderr=STDOUT) -> str:
         # the CommandError exception will contain the output as a string
         raise CommandError(e.output.decode('utf-8'))
 
-    # convert the output from bytes to a string when returning
-    return output.decode('utf-8')
+    # convert the output from bytes to a string when returning, replacing any
+    # byte sequences that are not valid utf-8 with the � character
+    return output.decode('utf-8', 'replace')
 
 
 class ChangeDirectoryContext:


### PR DESCRIPTION
gkeepcore.shell_command.run_command() uses decode() to convert the
output of shell commands from byte sequences to utf-8 before
returning. This used to raise a UnicodeDecodeError if the output
contains byte sequences that cannot be converted to utf-8. Now
the 'replace' error handler is used with decode() so that invalid
sequences are replaced with the � character.