### PR TITLE
Associate commit hashes with submissions

### DIFF
--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -165,6 +165,19 @@ def git_clone_remote(remote_repo_url, local_repo_path):
     run_command(cmd)
 
 
+def git_checkout(repo_path, branch_or_commit):
+    """
+    Checkout a branch or a commit in a repository.
+
+    :param repo_path: path of the repository
+    :param branch_or_commit: name of the branch or the commit hash to checkout
+    """
+
+    cmd = ['git', 'checkout', branch_or_commit]
+
+    run_command_in_directory(repo_path, cmd)
+
+
 def git_head_hash(repo_path):
     """
     Get the hash of the HEAD of a git repository.

--- a/git-keeper-server/gkeepserver/data/post-receive
+++ b/git-keeper-server/gkeepserver/data/post-receive
@@ -25,11 +25,12 @@ It must be executable.
 
 When it is run, a line like this is appended to the student's log:
 
-<timestamp> SUBMISSION <repo path>
+<timestamp> SUBMISSION <repo path> <commit hash>
 """
 
 import getpass
 import os
+import fileinput
 
 from gkeepcore.log_file import log_append_command
 from gkeepcore.path_utils import log_path_from_username
@@ -38,8 +39,17 @@ from gkeepcore.shell_command import run_command
 
 def main():
     log_path = log_path_from_username(getpass.getuser())
-    command = log_append_command(log_path, 'SUBMISSION', os.getcwd())
-    run_command(command)
+
+    # hash and reference information comes from stdin
+    for line in fileinput.input():
+        # each line is of the form "<old hash> <new hash> <ref name>"
+        split_fields = line.split()
+        new_hash = split_fields[1]
+
+        payload = '{} {}'.format(os.getcwd(), new_hash)
+
+        command = log_append_command(log_path, 'SUBMISSION', payload)
+        run_command(command)
 
 
 if __name__ == '__main__':

--- a/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
@@ -41,11 +41,12 @@ class SubmissionHandler(EventHandler):
         """Take action after a student pushes a new submission."""
 
         print('Handling submission:')
-        print(' Student:   ', self._student_username)
-        print(' Faculty:   ', self._faculty_username)
-        print(' Class:     ', self._class_name)
-        print(' Assignment:', self._assignment_name)
-        print(' Repo path: ', self._submission_repo_path)
+        print(' Student:    ', self._student_username)
+        print(' Faculty:    ', self._faculty_username)
+        print(' Class:      ', self._class_name)
+        print(' Assignment: ', self._assignment_name)
+        print(' Repo path:  ', self._submission_repo_path)
+        print(' Commit hash:', self._commit_hash)
         print()
 
         # We need to create a submission object to put in the
@@ -79,8 +80,9 @@ class SubmissionHandler(EventHandler):
             student = student_from_username(self._student_username, reader)
 
         submission = Submission(student, self._submission_repo_path,
-                                tests_path, reports_repo_path,
-                                self._faculty_username, faculty_email)
+                                self._commit_hash, tests_path,
+                                reports_repo_path, self._faculty_username,
+                                faculty_email)
 
         new_submission_queue.put(submission)
 
@@ -113,8 +115,9 @@ class SubmissionHandler(EventHandler):
 
         self._parse_log_path()
 
-        # the payload simply contains the submission repository path
-        self._submission_repo_path = self._payload
+        # the payload contains the submission repository path and the hash of
+        # the commit of the submission
+        self._submission_repo_path, self._commit_hash = self._payload.split()
 
         self._parse_repo_path()
 


### PR DESCRIPTION
Previously, tests were always run on the latest commit of the master
branch of the student's repository. If a student pushed twice before
the server had a chance to process the first submission, tests would
be run twice on the code from the second submission.

Now the post-receive hook logs the hash of the latest commit, and
that hash is used to checkout that specific commit before running
tests.

This also means that tests will be run on a submission that is pushed
to any branch in the repository.