### PR TITLE
Add a pre-receive hook to catch problematic pushes

### DIFF
--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -126,6 +126,21 @@ def git_pull(repo_path, remote_url=None):
     run_command_in_directory(repo_path, cmd)
 
 
+def git_config(repo_path, config_options):
+    """
+    Run a git config command on a repository.
+
+    :param repo_path: path to the repository
+    :param config_options: an iterable containing the options to pass to git
+      config
+    """
+
+    cmd = ['git', 'config']
+    cmd.extend(config_options)
+
+    run_command_in_directory(repo_path, cmd)
+
+
 def is_non_bare_repo(repo_path):
     """
     Determine if a directory is a non-bare git repository by checking for the

--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -24,7 +24,7 @@ from pkg_resources import resource_exists, resource_string, ResolutionError, \
     ExtractionError
 
 from gkeepcore.git_commands import git_init_bare, git_init, git_add_all, \
-    git_commit, git_push
+    git_commit, git_push, git_config
 from gkeepcore.gkeep_exception import GkeepException
 from gkeepcore.path_utils import parse_faculty_assignment_path, \
     user_home_dir, faculty_class_dir_path, student_assignment_repo_path, \
@@ -224,12 +224,16 @@ def create_base_code_repo(assignment_dir: AssignmentDirectory,
 
         # put the git hook scripts in place
         hook_script_names = ('pre-receive', 'post-receive')
-
         for script_name in hook_script_names:
             script_path = os.path.join(assignment_dir.base_code_repo_path,
                                        'hooks', script_name)
             write_git_hook_script(script_name, script_path)
             chmod(script_path, '750')
+
+        # configure the repository so that it will not accept destructive
+        # pushes
+        git_config(assignment_dir.base_code_repo_path,
+                   ('receive.denyNonFastForwards', 'true'))
 
     except GkeepException as e:
         error = 'error building base code repository: {0}'.format(str(e))

--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -184,7 +184,8 @@ def create_base_code_repo(assignment_dir: AssignmentDirectory,
     Create a bare repository in an assignment directory which contains the
     base code for an assignment, a post-receive hook script for triggering
     tests, and a pre-receive hook for ensuring the students only push to
-    the master branch and they do not perform destructive pushes.
+    the master branch. The repository is configured to reject destructive
+    pushes.
 
     Raises an AssignmentDirectoryError if anything goes wrong.
 

--- a/git-keeper-server/gkeepserver/data/pre-receive
+++ b/git-keeper-server/gkeepserver/data/pre-receive
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# This hook prevents students from doing any of the following:
+#   - pushing to a branch other than master
+#   - force pushing
+#   - deleting the master branch
+#
+# If this script exits with a 0 exit code the push is accepted, otherwise the
+# push is rejected.
+
+# we will only allow pushes to the master branch
+allowed_ref='refs/heads/master'
+
+# regex for determining if the push is destructive (force push or delete)
+destructive_pattern='force|\-f|delete'
+
+# determine the command used to push
+push_command=$(ps -ocommand= -p $PPID)
+
+# this hook receives push information about each ref that is pushed in the
+# form <old hash> <new hash> <ref name>
+while read old_hash new_hash ref_name
+do
+    if [ $ref_name != $allowed_ref ]
+    then
+        echo "ERROR: You may only push to the master branch"
+        exit 1
+    fi
+
+    if [[ $push_command =~ $destructive_pattern ]]
+    then
+        echo "ERROR: You may not force push to git-keeper"
+        exit 1
+    fi
+done
+
+exit 0

--- a/git-keeper-server/gkeepserver/data/pre-receive
+++ b/git-keeper-server/gkeepserver/data/pre-receive
@@ -15,22 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-# This hook prevents students from doing any of the following:
-#   - pushing to a branch other than master
-#   - force pushing
-#   - deleting the master branch
+# This hook prevents students from pushing to a branch other than master.
 #
 # If this script exits with a 0 exit code the push is accepted, otherwise the
 # push is rejected.
 
 # we will only allow pushes to the master branch
 allowed_ref='refs/heads/master'
-
-# regex for determining if the push is destructive (force push or delete)
-destructive_pattern='force|\-f|delete'
-
-# determine the command used to push
-push_command=$(ps -ocommand= -p $PPID)
 
 # this hook receives push information about each ref that is pushed in the
 # form <old hash> <new hash> <ref name>
@@ -39,12 +30,6 @@ do
     if [ $ref_name != $allowed_ref ]
     then
         echo "ERROR: You may only push to the master branch"
-        exit 1
-    fi
-
-    if [[ $push_command =~ $destructive_pattern ]]
-    then
-        echo "ERROR: You may not force push to git-keeper"
         exit 1
     fi
 done


### PR DESCRIPTION
The hook script checks to make sure that the student is not pushing
to a branch other than master and that they are not performing a
force push. If they try either of these, the push is rejected.