### PR TITLE
Use git-shell for student accounts

### DIFF
--- a/git-keeper-server/gkeepserver/create_user.py
+++ b/git-keeper-server/gkeepserver/create_user.py
@@ -134,7 +134,7 @@ def create_git_shell_commands(username: str, command_list: list):
 
 
 def create_user(username, user_type, first_name, last_name, email_address=None,
-                additional_groups=None):
+                additional_groups=None, shell='bash'):
     """
     Create a faculty or a student user, email them their credentials, and start
     watching their log file for events.
@@ -150,6 +150,7 @@ def create_user(username, user_type, first_name, last_name, email_address=None,
     :param email_address: email address of the user
     :param additional_groups: groups beyond the default group to add the user
      to
+    :param shell: name of the shell for the user
     """
 
     if username == config.faculty_group or username == config.student_group:
@@ -158,9 +159,6 @@ def create_user(username, user_type, first_name, last_name, email_address=None,
         raise GkeepException(error)
 
     logger.log_info('Creating user {0}'.format(username))
-
-    # for now everyone gets bash, students may eventually get git-shell
-    shell = 'bash'
 
     sudo_add_user(username, additional_groups, shell)
 

--- a/git-keeper-server/gkeepserver/event_handlers/class_add_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/class_add_handler.py
@@ -17,13 +17,15 @@
 """Provides a handler for handling classes added by faculty."""
 
 import os
+from shutil import which
 
 from gkeepcore.local_csv_files import LocalCSVReader
 from gkeepcore.path_utils import user_from_log_path, student_class_dir_path, \
     user_home_dir, faculty_class_dir_path, class_student_csv_path
 from gkeepcore.shell_command import CommandError
 from gkeepcore.student import students_from_csv
-from gkeepcore.system_commands import user_exists, mkdir, sudo_chown, cp, chmod
+from gkeepcore.system_commands import user_exists, mkdir, sudo_chown, cp, \
+    chmod, make_symbolic_link
 from gkeepcore.valid_names import validate_class_name
 from gkeepserver.create_user import create_user, UserType
 from gkeepserver.event_handler import EventHandler, HandlerException
@@ -129,7 +131,16 @@ class ClassAddHandler(EventHandler):
                 create_user(student.username, UserType.student,
                             student.first_name, student.last_name,
                             email_address=student.email_address,
-                            additional_groups=groups)
+                            additional_groups=groups, shell='git-shell')
+                home_dir = user_home_dir(student.username)
+
+                # use git-shell so that the only command students can run on
+                # the server is passwd
+                git_shell_commands_path = os.path.join(home_dir,
+                                                       'git-shell-commands')
+                mkdir(git_shell_commands_path, sudo=True)
+                make_symbolic_link(which('passwd'), git_shell_commands_path,
+                                   sudo=True)
             except Exception as e:
                 error = 'Error adding user {0}: {1}'.format(student.username,
                                                             e)


### PR DESCRIPTION
The shell for student accounts is set to git-shell. Now the only
command that students are allowed to run on the server is passwd.