### PR TITLE
Allow action.py as an action script

### DIFF
--- a/git-keeper-client/gkeepclient/server_actions.py
+++ b/git-keeper-client/gkeepclient/server_actions.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -240,13 +240,20 @@ def update_assignment(class_name: str, upload_dir_path: str,
     upload, and waits for a logged confirmation of success or error from the
     server.
 
-    Raises UpdateAssignmentError if anything goes wrong.
+    Raises a GkeepException if anything goes wrong.
 
     :param class_name: name of the class the assignment belongs to
     :param upload_dir_path: path to the assignment
     :param items: tuple or list of items to update
     :param response_timeout: seconds to wait for server response
     """
+
+    valid_items = {'base_code', 'email', 'tests'}
+
+    for item in items:
+        if item not in valid_items:
+            error = '{} is not a valid update item'.format(item)
+            raise GkeepException(error)
 
     # expand any special path components, strip trailing slash
     upload_dir_path = os.path.abspath(upload_dir_path)

--- a/git-keeper-core/gkeepcore/action_scripts.py
+++ b/git-keeper-core/gkeepcore/action_scripts.py
@@ -1,0 +1,61 @@
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Provides a function for determining what script to call and what interpreter
+to use to run an assignment's tests.
+"""
+
+import os
+from collections import OrderedDict
+
+
+# Any of these script names can be used for the entry point of an assignment's
+# tests. If more than one of these files exist, the one that appears first in
+# this ordered dictionary will be used. Each script name maps to the name of
+# the interpreter to use to call the script.
+interpreters_by_script_name = OrderedDict([
+    ('action.sh', 'bash'),
+    ('action.py', 'python3'),
+])
+
+
+def get_action_script_and_interpreter(directory_path: str):
+    """
+    Given the path to an assignment's tests directory, determine which script
+    will be called when running tests and what interpreter to use to call it.
+
+    :param directory_path:
+    :return: a tuple containing the name of the action script and the
+     interpreter that is used to run it. Returns (None, None) if no valid
+     action script was found.
+    """
+
+    if not os.path.isdir(directory_path):
+        return None, None
+
+    script_name = None
+    interpreter = None
+
+    for item in os.listdir(directory_path):
+        full_path = os.path.join(directory_path, item)
+
+        if os.path.isfile(full_path) and item in interpreters_by_script_name:
+            script_name = item
+            interpreter = interpreters_by_script_name[script_name]
+            break
+
+    return script_name, interpreter

--- a/git-keeper-core/gkeepcore/upload_directory.py
+++ b/git-keeper-core/gkeepcore/upload_directory.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ client.
 
 import os
 
+from gkeepcore.action_scripts import get_action_script_and_interpreter
 from gkeepcore.gkeep_exception import GkeepException
 from gkeepcore.path_utils import path_to_list
 
@@ -55,7 +56,8 @@ class UploadDirectory:
         email_path - path to email.txt
         base_code_path - path to the base_code directory
         tests_path = path to the tests directory
-        action_sh_path - path to action.sh
+        action_script_path - path to action script
+        action_script_interpreter - name of interpreter to run action script
     """
 
     def __init__(self, path, check=True):
@@ -72,22 +74,30 @@ class UploadDirectory:
         self.email_path = os.path.join(self.path, 'email.txt')
         self.base_code_path = os.path.join(self.path, 'base_code')
         self.tests_path = os.path.join(self.path, 'tests')
-        self.action_sh_path = os.path.join(self.tests_path, 'action.sh')
 
         self.assignment_name = path_to_list(self.path)[-1]
 
+        self.action_script, self.action_script_interpreter = \
+            get_action_script_and_interpreter(self.tests_path)
+
+        if self.action_script is not None:
+            self.action_script_path = os.path.join(self.tests_path,
+                                                   self.action_script)
+        else:
+            self.action_script_path = None
+
         if check:
-            self._ensure_items_exist()
+            self.action_script, self.action_script_interpreter = \
+                get_action_script_and_interpreter(self.tests_path)
 
-    def _ensure_items_exist(self):
-        # Raise an exception if any required directories or files are missing
+            if self.action_script is None:
+                raise UploadDirectoryError('action script')
 
-        # ensure all required directories exist
-        for dir_path in (self.path, self.base_code_path, self.tests_path):
-            if not os.path.isdir(dir_path):
-                raise UploadDirectoryError(dir_path)
+            # ensure all required directories exist
+            for dir_path in (self.path, self.base_code_path, self.tests_path):
+                if not os.path.isdir(dir_path):
+                    raise UploadDirectoryError(dir_path)
 
-        # ensure all required files exist
-        for file_path in (self.email_path, self.action_sh_path):
-            if not os.path.isfile(file_path):
-                raise UploadDirectoryError(file_path)
+            # ensure email.txt exists
+            if not os.path.isfile(self.email_path):
+                raise UploadDirectoryError(self.email_path)

--- a/git-keeper-server/gkeepserver/check_system.py
+++ b/git-keeper-server/gkeepserver/check_system.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2017, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -157,9 +157,6 @@ def check_paths_and_permissions():
     if not os.path.isfile(config.gitconfig_file_path):
         write_gitconfig()
 
-    if not os.path.isfile(config.run_action_sh_file_path):
-        write_run_action_sh()
-
 
 def write_gitconfig():
     """
@@ -177,31 +174,6 @@ def write_gitconfig():
         raise CheckSystemError(error)
 
     gkeepd_logger.log_info('Created {0}'.format(config.gitconfig_file_path))
-
-
-def write_run_action_sh():
-    """Write the contents of data/run_action.sh to the proper file."""
-
-    if not resource_exists('gkeepserver', 'data/run_action.sh'):
-        raise CheckSystemError('run_action.sh does not exist in the package')
-
-    try:
-        script_text = resource_string('gkeepserver', 'data/run_action.sh')
-        script_text = script_text.decode()
-    except Exception as e:
-        raise CheckSystemError('error reading run_action.sh data: {0}'
-                               .format(e))
-
-    try:
-        with open(config.run_action_sh_file_path, 'w') as f:
-            f.write(script_text)
-    except OSError as e:
-        error = 'error writing {0}: {1}'.format(config.run_action_sh_file_path,
-                                                e)
-        raise CheckSystemError(error)
-
-    sudo_chown(config.run_action_sh_file_path, config.tester_user,
-               config.keeper_group)
 
 
 def setup_faculty(faculty: Faculty):

--- a/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2017, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -64,7 +64,6 @@ class SubmissionHandler(EventHandler):
                                                       faculty_home_dir)
         assignment_directory = AssignmentDirectory(assignment_path)
 
-        tests_path = assignment_directory.tests_path
         reports_repo_path = assignment_directory.reports_repo_path
 
         reader = LocalCSVReader(class_student_csv_path(self._class_name,
@@ -79,8 +78,8 @@ class SubmissionHandler(EventHandler):
             student = student_from_username(self._student_username, reader)
 
         submission = Submission(student, self._submission_repo_path,
-                                tests_path, reports_repo_path,
-                                self._faculty_username, faculty_email)
+                                assignment_directory, self._faculty_username,
+                                faculty_email)
 
         new_submission_queue.put(submission)
 

--- a/git-keeper-server/gkeepserver/event_handlers/trigger_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/trigger_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2017, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,9 +98,7 @@ class TriggerHandler(EventHandler):
                                              self._assignment_name, home_dir)
 
             submission = Submission(student, submission_repo_path,
-                                    assignment_dir.tests_path,
-                                    assignment_dir.reports_repo_path,
-                                    self._faculty_username,
+                                    assignment_dir, self._faculty_username,
                                     faculty_email)
             new_submission_queue.put(submission)
 

--- a/git-keeper-server/gkeepserver/event_handlers/update_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/update_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ from gkeepcore.upload_directory import UploadDirectory
 from gkeepserver.assignments import AssignmentDirectory, \
     create_base_code_repo, copy_email_txt_file, \
     copy_tests_dir, remove_student_assignment, setup_student_assignment, \
-    StudentAssignmentError
+    StudentAssignmentError, write_run_action_sh
 from gkeepserver.event_handler import EventHandler, HandlerException
 from gkeepserver.gkeepd_logger import gkeepd_logger
 from gkeepserver.handler_utils import log_gkeepd_to_faculty
@@ -130,8 +130,14 @@ class UpdateHandler(EventHandler):
             copy_email_txt_file(assignment_dir, upload_dir.email_path)
 
         if os.path.isdir(upload_dir.tests_path):
+            if upload_dir.action_script is None:
+                error = 'No action script in tests directory'
+                raise GkeepException(error)
+
             rm(assignment_dir.tests_path, recursive=True)
             copy_tests_dir(assignment_dir, upload_dir.tests_path)
+
+            write_run_action_sh(assignment_dir, upload_dir)
 
         # sanity check
         assignment_dir.check()

--- a/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2017, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,7 +33,8 @@ from gkeepcore.upload_directory import UploadDirectory, UploadDirectoryError
 from gkeepcore.valid_names import validate_assignment_name
 from gkeepserver.assignments import AssignmentDirectory, \
     AssignmentDirectoryError, create_base_code_repo, copy_email_txt_file, \
-    copy_tests_dir, setup_student_assignment, StudentAssignmentError
+    copy_tests_dir, setup_student_assignment, StudentAssignmentError, \
+    write_run_action_sh
 from gkeepserver.event_handler import EventHandler, HandlerException
 from gkeepserver.gkeepd_logger import gkeepd_logger
 from gkeepserver.handler_utils import log_gkeepd_to_faculty
@@ -157,6 +158,8 @@ class UploadHandler(EventHandler):
         except GkeepException as e:
             error = ('error copying assignment files: {0}'.format(str(e)))
             raise HandlerException(error)
+
+        write_run_action_sh(assignment_dir, upload_dir)
 
         # set permissions on assignment directory
         try:

--- a/git-keeper-server/gkeepserver/server_configuration.py
+++ b/git-keeper-server/gkeepserver/server_configuration.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nathan Sommer and Ben Coleman
+# Copyright 2016, 2018 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -186,6 +186,8 @@ class ServerConfiguration:
 
         # testing student code
         self.test_thread_count = 1
+        self.tests_timeout = 300
+        self.tests_memory_limit = 1024
 
         # users and groups
         self.keeper_user = 'keeper'


### PR DESCRIPTION
Previously, action.sh was the only action script allowed for an
assignment's tests. Now one can also use action.py, which will be
run using python3 as the interpreter.

If both action.sh and action.py exist, action.sh will be run.

In the future, support for new allowed action scripts can be added
easily.