### PR TITLE
Support using paths for assignment names with gkeep

### DIFF
--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -27,6 +27,7 @@ import sys
 from argparse import ArgumentParser
 
 from gkeepclient.version import __version__ as client_version
+from gkeepcore.path_utils import path_to_assignment_name
 from gkeepcore.version import __version__ as core_version
 
 from argcomplete import autocomplete
@@ -381,6 +382,11 @@ def take_action(parsed_args):
     if class_name and class_name in config.class_aliases:
         class_name = config.class_aliases[class_name]
 
+    # the user may pass a path for the name of an assignment
+    assignment_name = getattr(parsed_args, 'assignment_name', None)
+    if assignment_name:
+        assignment_name = path_to_assignment_name(assignment_name)
+
     # call the appropriate function for the action
     if action_name == 'add':
         class_add(class_name, parsed_args.csv_file_path)
@@ -395,18 +401,18 @@ def take_action(parsed_args):
             items = (parsed_args.item,)
         update_assignment(class_name, parsed_args.assignment_path, items)
     elif action_name == 'publish':
-        publish_assignment(class_name, parsed_args.assignment_name)
+        publish_assignment(class_name, assignment_name)
     elif action_name == 'delete':
-        delete_assignment(class_name, parsed_args.assignment_name)
+        delete_assignment(class_name, assignment_name)
     elif action_name == 'fetch':
         dest_path = build_dest_path(parsed_args.destination_path,
                                     class_name)
-        fetch_submissions(class_name, parsed_args.assignment_name,
+        fetch_submissions(class_name, assignment_name,
                           dest_path)
     elif action_name == 'query':
         run_query(parsed_args.query_type, parsed_args.number_of_days)
     elif action_name == 'trigger':
-        trigger_tests(class_name, parsed_args.assignment_name,
+        trigger_tests(class_name, assignment_name,
                       parsed_args.student_usernames)
     elif action_name == 'config':
         create_config()

--- a/git-keeper-core/gkeepcore/path_utils.py
+++ b/git-keeper-core/gkeepcore/path_utils.py
@@ -46,6 +46,26 @@ def path_to_list(path: str) -> list:
     return elements
 
 
+def path_to_assignment_name(path: str) -> str:
+    """
+    Extract an assignment name from a path. This simply returns the last
+    element in a path, and does not ensure that the name is a valid assignment
+    name.
+
+    If given an empty string, the empty string is returned.
+
+    :param path: assignment path
+    :return: name of the assignment
+    """
+
+    path_components = path_to_list(path)
+
+    if len(path_components) == 0:
+        return ''
+    else:
+        return path_components[-1]
+
+
 def user_home_dir(username):
     """
     Get a user's home directory on the local machine.

--- a/git-keeper-core/gkeepcore/upload_directory.py
+++ b/git-keeper-core/gkeepcore/upload_directory.py
@@ -23,7 +23,7 @@ import os
 
 from gkeepcore.action_scripts import get_action_script_and_interpreter
 from gkeepcore.gkeep_exception import GkeepException
-from gkeepcore.path_utils import path_to_list
+from gkeepcore.path_utils import path_to_assignment_name
 
 
 class UploadDirectoryError(GkeepException):
@@ -75,7 +75,7 @@ class UploadDirectory:
         self.base_code_path = os.path.join(self.path, 'base_code')
         self.tests_path = os.path.join(self.path, 'tests')
 
-        self.assignment_name = path_to_list(self.path)[-1]
+        self.assignment_name = path_to_assignment_name(self.path)
 
         self.action_script, self.action_script_interpreter = \
             get_action_script_and_interpreter(self.tests_path)


### PR DESCRIPTION
If any gkeep command is run that accepts an assignment name, the string
is first treated as a path and the name becomes the last element of the
path, with any trailing slashes removed.