### PR TITLE
Ensure new home directories have 755 permissions

### DIFF
--- a/git-keeper-core/gkeepcore/system_commands.py
+++ b/git-keeper-core/gkeepcore/system_commands.py
@@ -24,6 +24,7 @@ from grp import getgrgid, getgrnam
 from pwd import getpwuid, getpwnam
 from shutil import which
 
+from gkeepcore.path_utils import user_home_dir
 from gkeepcore.shell_command import run_command, CommandError
 
 
@@ -124,7 +125,7 @@ def sudo_add_group(group):
     run_command(cmd, sudo=True)
 
 
-def sudo_add_user(username, groups=None, shell=None):
+def sudo_add_user(username, groups=None, shell=None, home_dir_mode=755):
     """
     Add a new user to the system using sudo and useradd.
 
@@ -138,6 +139,8 @@ def sudo_add_user(username, groups=None, shell=None):
     :param username: username of the new user
     :param groups: additional groups that the user shoul be in
     :param shell: name of the user's shell, will be bash if None
+    :param home_dir_mode: read, write, and execute permissions for the user's
+     home directory, defaults to 755
     """
 
     if shell is None:
@@ -154,6 +157,9 @@ def sudo_add_user(username, groups=None, shell=None):
     cmd += [username]
 
     run_command(cmd, sudo=True)
+
+    home_dir_path = user_home_dir(username)
+    chmod(home_dir_path, home_dir_mode, sudo=True)
 
 
 def sudo_set_password(username, password):
@@ -343,3 +349,16 @@ def rm(path, recursive=False, sudo=False):
     cmd.append(path)
 
     run_command(cmd, sudo=sudo)
+
+
+def file_is_readable(path):
+    """
+    Check to see if a file is readable.
+
+    Returns True if the file is readable, False if it is not.
+
+    :param path: path to the file
+    :return: True if the file is readable, False if it is not
+    """
+
+    return os.access(path, os.R_OK)

--- a/git-keeper-server/gkeepserver/log_polling.py
+++ b/git-keeper-server/gkeepserver/log_polling.py
@@ -62,6 +62,7 @@ from time import time, sleep
 
 from gkeepcore.gkeep_exception import GkeepException
 from gkeepcore.log_file import LogFileReader, LogFileException
+from gkeepcore.system_commands import file_is_readable
 from gkeepserver.gkeepd_logger import GkeepdLoggerThread
 
 
@@ -148,6 +149,10 @@ class LogPollingThread(Thread):
         :param file_path: path to the log file
 
         """
+
+        if not file_is_readable(file_path):
+            error = '{} is not a readable file'.format(file_path)
+            raise GkeepException(error)
 
         self._add_log_queue.put(file_path)
 


### PR DESCRIPTION
Previously there was an assumption that the system would create new
home directories with a mode of 755. Certain Linux distributions do
not do this, so now the permissions of new home directories are set
explicitly. This ensures that the keeper user can read all user logs.