### PR TITLE
Fix Gkeep Add Fails keyword and Duplicate Class Name test

### DIFF
--- a/git-keeper-robot/gkeeprobot/exceptions.py
+++ b/git-keeper-robot/gkeeprobot/exceptions.py
@@ -1,0 +1,24 @@
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+This module provides exceptions to be raised by robot keyword functions.
+"""
+
+
+class GkeepRobotException(Exception):
+    """Base exception for all robot exceptions."""
+    pass

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -16,6 +16,7 @@
 
 from gkeeprobot.control.ClientControl import ClientControl
 from gkeepcore.shell_command import CommandError
+from gkeeprobot.exceptions import GkeepRobotException
 
 """Provides keywords used by robotframework to check the results of
 user actions."""
@@ -33,7 +34,7 @@ class ClientCheckKeywords:
         try:
             cmd = 'gkeep add {} {}.csv'.format(class_name, class_name)
             client_control.run(faculty, cmd)
-            raise CommandError('gkeep add should have non-zero return')
+            raise GkeepRobotException('gkeep add should have non-zero return')
         except CommandError:
             pass
 

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -82,7 +82,7 @@ Student Named Student
     Gkeep Add Fails    faculty=washington    class_name=cs1
 
 Duplicate Class Name
-    [Tags]    error
+    [Tags]    happy_path
     Setup Faculty Accounts    washington    adams
     Add To Class    faculty=washington    class_name=cs1    student=kermit
     Gkeep Add Succeeds    faculty=washington    class_name=cs1

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -87,7 +87,7 @@ Duplicate Class Name
     Add To Class    faculty=washington    class_name=cs1    student=kermit
     Gkeep Add Succeeds    faculty=washington    class_name=cs1
     Add To Class    faculty=adams    class_name=cs1    student=gonzo
-    Gkeep Add Fails    faculty=adams    class_name=cs1
+    Gkeep Add Succeeds    faculty=adams    class_name=cs1
 
 Empty CSV
     [Tags]    error


### PR DESCRIPTION
Previously Gkeep Add Fails was never raising an exception. A new
exception class was created named GkeepRobotException to be raised
by robot tests when there are errors.