### PR TITLE
Manual testing

### DIFF
--- a/git-keeper-robot/gkeeprobot/control/VMControl.py
+++ b/git-keeper-robot/gkeeprobot/control/VMControl.py
@@ -13,9 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from gkeepcore.system_commands import chmod
 from gkeepcore.shell_command import run_command
 from tempfile import TemporaryDirectory
-from robot.api import logger
+
 
 """Provides methods to execute commands on gkclient and gkserver
 during testing."""
@@ -39,6 +40,8 @@ class VMControl:
         base = 'ssh localhost'
         port = '-p {}'.format(port)
         if username == 'keeper':
+            chmod('ssh_keys/keeper_rsa', '600')
+            chmod('ssh_keys/keeper_rsa.pub', '600')
             user_and_key = '-l {} -i ssh_keys/{}_rsa'.format(username,
                                                              username)
         else:
@@ -56,6 +59,8 @@ class VMControl:
         base = 'scp'
         port = '-P {}'.format(port)
         if username == 'keeper':
+            chmod('ssh_keys/keeper_rsa', '600')
+            chmod('ssh_keys/keeper_rsa.pub', '600')
             key = '-i ssh_keys/{}_rsa'.format(username)
         else:
             key = '-i {}/{}_rsa'.format(self.temp_dir.name, username)

--- a/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
@@ -64,5 +64,9 @@ class ClientSetupKeywords:
         client_control.run_vm_bash_script(faculty, 'make_gkeep_config.sh',
                                           faculty)
 
+    def run_gkeep_command(self, faculty, *command):
+        cmd = 'gkeep ' + ' '.join(command)
+        client_control.run(faculty, cmd)
+
     def reset_client(self):
         client_control.run_vm_python_script('keeper', 'reset_client.py')

--- a/tests/acceptance/manual_configure.py
+++ b/tests/acceptance/manual_configure.py
@@ -8,17 +8,31 @@ client = ClientSetupKeywords()
 
 print('Checking that gkserver is running...')
 if not vagrant.is_server_running():
-    print("Server not running!")
+    print("Server not running.  Run 'vagrant up' first.")
     exit(1)
 
 print('Checking that gkclient is running')
 if not vagrant.is_client_running():
-    print("Client not running!")
+    print("Client not running.  Run 'vagrant up' first.")
     exit(1)
 
+print('Copying valid server.cfg')
+server.add_file_to_server('keeper', 'files/valid_server.cfg', 'server.cfg')
 print('Starting server with admin_prof as admin')
-server.add_file_to_server('keeper' 'files/valid_server.cfg', 'server.cfg')
 server.start_gkeepd()
+
+print('Making admin_prof account on gkclient')
+client.create_accounts('admin_prof')
+client.establish_ssh_keys('admin_prof')
+client.create_gkeep_config_file('admin_prof')
+
+print('Adding prof1 as faculty on gkserver')
+client.run_gkeep_command('admin_prof', 'add_faculty', 'prof1', 'doctor', 'prof1@gitkeeper.edu')
+
+print('Making prof1 account on gkclient')
+client.create_accounts('prof1')
+client.establish_ssh_keys('prof1')
+client.create_gkeep_config_file('prof1')
 
 
 

--- a/tests/acceptance/manual_configure.py
+++ b/tests/acceptance/manual_configure.py
@@ -1,0 +1,24 @@
+from gkeeprobot.control.VagrantControl import VagrantControl
+from gkeeprobot.keywords.ServerSetupKeywords import ServerSetupKeywords
+from gkeeprobot.keywords.ClientSetupKeywords import ClientSetupKeywords
+
+vagrant = VagrantControl()
+server = ServerSetupKeywords()
+client = ClientSetupKeywords()
+
+print('Checking that gkserver is running...')
+if not vagrant.is_server_running():
+    print("Server not running!")
+    exit(1)
+
+print('Checking that gkclient is running')
+if not vagrant.is_client_running():
+    print("Client not running!")
+    exit(1)
+
+print('Starting server with admin_prof as admin')
+server.add_file_to_server('keeper' 'files/valid_server.cfg', 'server.cfg')
+server.start_gkeepd()
+
+
+

--- a/tests/acceptance/manual_configure.py
+++ b/tests/acceptance/manual_configure.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from gkeeprobot.control.VagrantControl import VagrantControl
 from gkeeprobot.keywords.ServerSetupKeywords import ServerSetupKeywords
 from gkeeprobot.keywords.ClientSetupKeywords import ClientSetupKeywords

--- a/tests/acceptance/manual_reset.py
+++ b/tests/acceptance/manual_reset.py
@@ -1,0 +1,25 @@
+
+from gkeeprobot.control.VagrantControl import VagrantControl
+from gkeeprobot.keywords.ServerSetupKeywords import ServerSetupKeywords
+from gkeeprobot.keywords.ClientSetupKeywords import ClientSetupKeywords
+
+vagrant = VagrantControl()
+server = ServerSetupKeywords()
+client = ClientSetupKeywords()
+
+print('Checking that gkserver is running...')
+if not vagrant.is_server_running():
+    print("Server not running!")
+    exit(1)
+
+print('Checking that gkclient is running')
+if not vagrant.is_client_running():
+    print("Client not running!")
+    exit(1)
+
+# This also stops gkeepd
+print("Resetting server...")
+server.reset_server()
+print('Resetting client...')
+client.reset_client()
+

--- a/tests/acceptance/manual_reset.py
+++ b/tests/acceptance/manual_reset.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from gkeeprobot.control.VagrantControl import VagrantControl
 from gkeeprobot.keywords.ServerSetupKeywords import ServerSetupKeywords

--- a/tests/acceptance/manual_reset.py
+++ b/tests/acceptance/manual_reset.py
@@ -9,12 +9,12 @@ client = ClientSetupKeywords()
 
 print('Checking that gkserver is running...')
 if not vagrant.is_server_running():
-    print("Server not running!")
+    print("Server not running.  Run 'vagrant up' first.")
     exit(1)
 
 print('Checking that gkclient is running')
 if not vagrant.is_client_running():
-    print("Client not running!")
+    print("Client not running.  Run 'vagrant up' first.")
     exit(1)
 
 # This also stops gkeepd


### PR DESCRIPTION

Adds scripts to assist when manually running tests.

`manual_config.py` will:
* Start `gkeepd` with `admin_prof` as the admin account
* Create `admin_prof` account on `gkclient` (with ssh keys and client.cfg)
* Using `admin_prof` to add `prof1` as a faculty account
* Create `prof1` account on `gkclient` (with ssh keys and client.cfg)

`manual_reset.py` will:
* Return `gkserver` to the same state as when launched (delete files and accounts)
* Return `gkclient` to the same state as when launched (delete files and accounts)