### PR TITLE
Dup students

### DIFF
--- a/git-keeper-core/gkeepcore/student.py
+++ b/git-keeper-core/gkeepcore/student.py
@@ -143,7 +143,8 @@ def students_from_csv(reader: CSVReader) -> list:
 
     for row in reader.get_rows():
         if len(row) > 0:
-            students.append(Student.from_csv_row(row))
+            if Student.from_csv_row(row) not in students:
+                students.append(Student.from_csv_row(row))
 
     return students
 

--- a/tests/acceptance/gkeep_add_faculty.robot
+++ b/tests/acceptance/gkeep_add_faculty.robot
@@ -37,3 +37,11 @@ Duplicate Faculty
     Add Faculty    prof2
     Gkeep Add Faculty Fails    admin_prof    prof2
     Gkeepd Is Running
+    
+NonAdmin Adding Faculty
+    [Tags]  error
+    Add Faculty     prof2
+    User Exists     prof2
+    Setup Faculty Accounts  prof2
+    Gkeep Add Faculty Fails  prof2  prof3
+    Gkeepd Is Running

--- a/tests/acceptance/gkeep_modify.robot
+++ b/tests/acceptance/gkeep_modify.robot
@@ -36,6 +36,20 @@ Remove Student
     Gkeep Modify Succeeds    faculty=washington    class_name=cs1
     Gkeep Query Does Not Contain    washington    students    gonzo
 
+Add Student Twice
+    [Tags]    error
+    Establish Course  washington    cs1     @{cs1_students}
+    Add To Class    faculty=washington  class_name=cs1  student=piggy
+    Gkeep Modify Succeeds    faculty=washington    class_name=cs1
+    User Exists    piggy
+    Email Exists    to_user=piggy    contains=Password
+    Gkeep Query Contains    washington    students    piggy
+    Add To Class    faculty=washington   class_name=cs1  student=piggy
+    Gkeep Modify Succeeds    faculty=washington    class_name=cs1
+    User Exists    piggy
+    Email Exists    to_user=piggy    contains=Password
+    Gkeep Query Contains    washington    students    piggy
+
 *** Keywords ***
 
 Establish Course


### PR DESCRIPTION
Altered the loop that adds students from a csv file. Now duplicate student names SHOULD NOT be able to be added successfully. Changes were made to the student.py file found at the following path "/git-keeper/git-keeper-core/gkeepcore/student.py".