### PR TITLE
Added Malformed CSV test to gkeep_modify.

### DIFF
--- a/tests/acceptance/gkeep_modify.robot
+++ b/tests/acceptance/gkeep_modify.robot
@@ -42,6 +42,12 @@ Add Student Twice
     Add To Class    faculty=washington  class_name=cs1  student=kermit
     Gkeep Modify Fails   faculty=washington    class_name=cs1
 
+Malformed CSV
+    [Tags]    error
+    Establish Course  washington    cs1     @{cs1_students}
+    Add File To Client    washington    files/malformed_cs1.csv    cs1.csv
+    Gkeep Modify Fails    faculty=washington    class_name=cs1
+
 *** Keywords ***
 
 Establish Course


### PR DESCRIPTION
Implements a test that ensures that it is an error to use modify with a malformed csv file.