### PR TITLE
Add student named student test added to gkeep_modify

### DIFF
--- a/tests/acceptance/gkeep_modify.robot
+++ b/tests/acceptance/gkeep_modify.robot
@@ -48,6 +48,12 @@ Malformed CSV
     Add File To Client    washington    files/malformed_cs1.csv    cs1.csv
     Gkeep Modify Fails    faculty=washington    class_name=cs1
 
+Add Student Named Student
+    [Tags]    error
+    Setup Faculty Accounts    washington
+    Add To Class    faculty=washington  class_name=cs1  student=student
+    Gkeep Modify Fails    faculty=washington    class_name=cs1
+
 *** Keywords ***
 
 Establish Course


### PR DESCRIPTION
Implements a test that ensures that it is an error to try and add a student named "student" using gkeep modify. 