### PR TITLE
Add support for empty or ommitted CSV files with gkeep add

### DIFF
--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -98,13 +98,25 @@ def add_assignment_path_argument(subparser):
 
 def add_csv_file_path_argument(subparser):
     """
-    Add a csv_file_path argument to a subparser.
+    Add a required csv_file_path argument to a subparser.
 
     :param subparser: the subparser to add the argument to
     """
 
     subparser.add_argument('csv_file_path', type=str, metavar='<csv filename>',
                            help='name of the CSV file containing students')
+
+
+def add_optional_csv_file_path_argument(subparser):
+    """
+    Add an optional csv_file_path argument to a subparser.
+
+    :param subparser: the subparser to add the argument to
+    """
+
+    subparser.add_argument('csv_file_path', type=str, metavar='<csv filename>',
+                           help='name of the CSV file containing students',
+                           default=None, nargs='?')
 
 
 def add_add_subparser(subparsers):
@@ -116,7 +128,7 @@ def add_add_subparser(subparsers):
 
     subparser = subparsers.add_parser('add', help='add a class')
     add_class_name_argument(subparser)
-    add_csv_file_path_argument(subparser)
+    add_optional_csv_file_path_argument(subparser)
 
 
 def add_modify_subparser(subparsers):

--- a/git-keeper-client/gkeepclient/server_actions.py
+++ b/git-keeper-client/gkeepclient/server_actions.py
@@ -36,31 +36,37 @@ from gkeepcore.upload_directory import UploadDirectory
 @config_parsed
 @server_interface_connected
 @class_does_not_exist
-def class_add(class_name: str, csv_file_path: str):
+def class_add(class_name: str, csv_file_path: str=None):
     """
     Add a class on the server.
 
     :param class_name: name of the class
     :param csv_file_path: path to the CSV file of students
+           or None if the user is creating an empty class
     """
 
     validate_class_name(class_name)
 
-    if not os.path.isfile(csv_file_path):
-        raise GkeepException('{0} does not exist'.format(csv_file_path))
+    if csv_file_path is not None:
+        if not os.path.isfile(csv_file_path):
+            raise GkeepException('{0} does not exist'.format(csv_file_path))
 
-    students = students_from_csv(LocalCSVReader(csv_file_path))
+        students = students_from_csv(LocalCSVReader(csv_file_path))
 
-    print('Adding class {0} with the following students:'.format(class_name))
+        print('Adding class {0} with the following students:'.format(class_name))
 
-    for student in students:
-        print(student)
+        for student in students:
+            print(student)
 
-    # create directory and upload CSV
+    # create directory
     upload_dir_path = server_interface.create_new_upload_dir()
+
     remote_csv_file_path = os.path.join(upload_dir_path, 'students.csv')
 
-    server_interface.copy_file(csv_file_path, remote_csv_file_path)
+    if csv_file_path is None:
+        server_interface.create_empty_file(remote_csv_file_path)
+    else:
+        server_interface.copy_file(csv_file_path, remote_csv_file_path)
 
     print('CSV file uploaded')
 

--- a/git-keeper-client/gkeepclient/server_interface.py
+++ b/git-keeper-client/gkeepclient/server_interface.py
@@ -258,6 +258,20 @@ class ServerInterface:
         except Exception as e:
             raise ServerInterfaceError(e)
 
+    def create_empty_file(self, remote_path: str):
+        """
+        Create an empty file on the server.
+
+        It is the responsibility of the caller to ensure that the remote
+        path does not exist.
+
+        The remote_path is the full destination file path.
+
+        :param remote_path: full path on the server
+        """
+        cmd = ['touch', remote_path]
+        self.run_command(cmd)
+
     def create_directory(self, remote_path):
         """
         Create a new directory on the server.

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -30,6 +30,9 @@ class ClientCheckKeywords:
         client_control.run(faculty, 'gkeep add {} {}.csv'.format(class_name,
                                                                  class_name))
 
+    def gkeep_add_no_csv_succeeds(self, faculty, class_name):
+        client_control.run(faculty, 'gkeep add {}'.format(class_name))
+
     def gkeep_add_fails(self, faculty, class_name):
         try:
             cmd = 'gkeep add {} {}.csv'.format(class_name, class_name)

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -90,7 +90,13 @@ Duplicate Class Name
     Gkeep Add Succeeds    faculty=adams    class_name=cs1
 
 Empty CSV
-    [Tags]    error
+    [Tags]    happy_path
     Setup Faculty Accounts    washington
     Make Empty File    washington    cs1.csv
-    Gkeep Add Fails    faculty=washington    class_name=cs1
+    Gkeep Add Succeeds    faculty=washington    class_name=cs1
+
+No CSV
+    [Tags]  happy_path
+    Setup Faculty Accounts    washington
+    Make Empty File    washington    cs1.csv
+    Gkeep Add No CSV Succeeds    faculty=washington    class_name=cs1


### PR DESCRIPTION
This commit allows the user to create a class before there are
any students.  This will be useful for faculty who work well
in advance of the semester.

The faculty member can either use an empty CSV file or run `gkeep add`
with just the name of the class (i.e. without the CSV file specified).

NOTE: Previously `gkeep add cs1 empty.csv` with an empty csv would
succeed - which caused confusion when my intern tried to test
that it would fail.