### PR TITLE
Remove a home directory if the user does not exist

### DIFF
--- a/git-keeper-core/gkeepcore/system_commands.py
+++ b/git-keeper-core/gkeepcore/system_commands.py
@@ -162,6 +162,25 @@ def sudo_add_user(username, groups=None, shell=None, home_dir_mode=755):
     chmod(home_dir_path, home_dir_mode, sudo=True)
 
 
+def sudo_remove_user(username, home_dir_path=None):
+    """
+    Remove a user and the user's home directory.
+
+    If the user does not exist and home_dir_path is not none, home_dir_path
+    will be removed if it exists.
+
+    :param username: username of the user to remove
+    :param home_dir: optional path to a home directory that should be removed
+      even if the user does not exist
+    """
+
+    if user_exists(username):
+        cmd = 'userdel -r {}'.format(username)
+        run_command(cmd, sudo=True)
+    elif home_dir_path is not None and os.path.isdir(home_dir_path):
+        rm(home_dir_path, recursive=True, sudo=True)
+
+
 def sudo_set_password(username, password):
     """
     Set a user's password using sudo and chpasswd.

--- a/tests/acceptance/vm_scripts/reset_client.py
+++ b/tests/acceptance/vm_scripts/reset_client.py
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gkeepcore.shell_command import run_command
+
+from gkeepcore.system_commands import sudo_remove_user
 
 
 def remove_users():
@@ -23,7 +24,7 @@ def remove_users():
 
     for user in os.listdir('/home'):
         if user not in expected:
-            run_command('sudo userdel -r {}'.format(user))
+            sudo_remove_user(user, home_dir_path='/home/{}'.format(user))
 
 
 remove_users()

--- a/tests/acceptance/vm_scripts/reset_server.py
+++ b/tests/acceptance/vm_scripts/reset_server.py
@@ -14,8 +14,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from gkeepcore.shell_command import run_command, CommandError
 import os
+
+from gkeepcore.shell_command import run_command, CommandError
+from gkeepcore.system_commands import sudo_remove_user
 
 
 def server_running():
@@ -58,7 +60,7 @@ def remove_users():
 
     for user in os.listdir('/home'):
         if user not in expected:
-            run_command('sudo userdel -r {}'.format(user))
+            sudo_remove_user(user, home_dir_path='/home/{}'.format(user))
 
 
 stop_gkeepd()


### PR DESCRIPTION
When resetting the client and server during tests, if there is
a home directory that exists but there is no user that it belongs to,
the directory will be removed.