### PR TITLE
Upload tests

### DIFF
--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -88,3 +88,15 @@ class ClientCheckKeywords:
             raise GkeepRobotException(error)
         except ExitCodeException:
             pass
+
+    def gkeep_upload_succeeds(self, faculty, course_name, assignment_name):
+        client_control.run(faculty, 'gkeep upload {} {}'.format(course_name, assignment_name))
+
+    def gkeep_upload_fails(self, faculty, course_name, assignment_name):
+        try:
+            client_control.run(faculty, 'gkeep upload {} {}'.format(course_name, assignment_name))
+            error = 'gkeep upload should have non-zero return'
+            raise GkeepRobotException(error)
+        except ExitCodeException:
+            pass
+

--- a/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
@@ -70,3 +70,13 @@ class ClientSetupKeywords:
     def reset_client(self):
         client_control.close_user_connections()
         client_control.run_vm_python_script('keeper', 'reset_client.py')
+
+    def add_assignment(self, faculty, assignment_name):
+        cmd = 'cp -r /vagrant/assignments/{}/ ~'.format(assignment_name)
+        client_control.run(faculty, cmd)
+
+    def clone_assignment(self, student, faculty, class_name,assignment_name):
+        client_control.run(student, 'mkdir -p assignments')
+        url = '{}@gkserver:/home/{}/{}/{}/{}.git'.format(student, student, faculty, class_name, assignment_name)
+        command = 'git clone {} assignments'.format(url)
+        client_control.run(student, command)

--- a/tests/acceptance/assignments/good_simple/base_code/code.py
+++ b/tests/acceptance/assignments/good_simple/base_code/code.py
@@ -1,0 +1,3 @@
+
+def go():
+    pass

--- a/tests/acceptance/assignments/good_simple/email.txt
+++ b/tests/acceptance/assignments/good_simple/email.txt
@@ -1,0 +1,1 @@
+good_simple assignment

--- a/tests/acceptance/assignments/good_simple/tests/action.sh
+++ b/tests/acceptance/assignments/good_simple/tests/action.sh
@@ -1,0 +1,3 @@
+
+echo 'Done'
+exit 0

--- a/tests/acceptance/assignments/good_simple/tests/email.txt
+++ b/tests/acceptance/assignments/good_simple/tests/email.txt
@@ -1,0 +1,1 @@
+good_simple assignment

--- a/tests/acceptance/assignments/missing_email/base_code/code.py
+++ b/tests/acceptance/assignments/missing_email/base_code/code.py
@@ -1,0 +1,3 @@
+
+def go():
+    pass

--- a/tests/acceptance/assignments/missing_email/tests/action.sh
+++ b/tests/acceptance/assignments/missing_email/tests/action.sh
@@ -1,0 +1,3 @@
+
+echo 'Done'
+exit 0

--- a/tests/acceptance/assignments/missing_email/tests/email.txt
+++ b/tests/acceptance/assignments/missing_email/tests/email.txt
@@ -1,0 +1,1 @@
+good_simple assignment

--- a/tests/acceptance/gkclient_base/Vagrantfile
+++ b/tests/acceptance/gkclient_base/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         usermod -aG vagrant keeper
         echo 'keeper ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
         echo 'keeper:keeper' | chpasswd
-        apt-get update && apt-get install -y python3-pip libssl-dev
+        apt-get update && apt-get install -y python3-pip libssl-dev git
         apt-get clean
         sudo -H pip3 install -U pip setuptools
         pip3 install cryptography

--- a/tests/acceptance/gkeep_upload.robot
+++ b/tests/acceptance/gkeep_upload.robot
@@ -1,0 +1,42 @@
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+*** Settings ***
+Resource    resources/setup.robot
+Test Setup    Launch Gkeepd With Faculty    washington    adams
+Force Tags    gkeep_upload
+
+*** Test Cases ***
+Valid Assignment Upload
+    [Tags]  happy_path
+    Setup Faculty Accounts    washington
+    Add To Class    faculty=washington    class_name=cs1    student=kermit
+    Add To Class    faculty=washington    class_name=cs1    student=gonzo
+    Gkeep Add Succeeds    faculty=washington    class_name=cs1
+    Add Assignment  washington  good_simple
+    Gkeep Upload Succeeds   washington   cs1    good_simple
+    Email Exists  washington    good_simple
+    Clone Assignment    washington  washington  cs1  good_simple
+    gkeep query contains  washington    assignments  U good_simple
+
+Missing Email
+    [Tags]  error
+    Setup Faculty Accounts    washington
+    Add To Class    faculty=washington    class_name=cs1    student=kermit
+    Add To Class    faculty=washington    class_name=cs1    student=gonzo
+    Gkeep Add Succeeds    faculty=washington    class_name=cs1
+    Add Assignment  washington  missing_email
+    Gkeep Upload Fails   washington   cs1    missing_email


### PR DESCRIPTION

This PR contains code for testing of `gkeep upload`.  I had to change the following:

* Add `git` to `gkclient`!!!  See the git commit message for steps to rebuild and reinstall.  Also, note that you will need to remove `localhost:2200` from your `knownhosts` (otherwise you get a `BadHostKeyException`)
* Add two assignments for testing.  These assignments are minimal - not designed to be "real"  One is valid, and the other is missing the the `email.txt` file.  Assignments are stored in a new `assignments` folder and can be copied within the vagrant instances via `/vagrant/assignments`.
* The happy path test, which ensures that
  * `gkeep upload` succeeds
  * the faculty receives an email
  * `gkeep query assignments` contains the assignment
* Missing Email test that verifies that the `gkeep upload` command fails
