### PR TITLE
Add option to print JSON when querying 

### DIFF
--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -222,6 +222,8 @@ def add_query_subparser(subparsers):
     """
 
     subparser = subparsers.add_parser('query', help='query the server')
+    subparser.add_argument('--json', '-j', action='store_true',
+                           help='output JSON')
     subparser.add_argument('query_type', metavar='<query type>',
                            help='classes, assignments, recent, or students',
                            choices=['classes', 'assignments', 'recent',
@@ -333,21 +335,24 @@ def initialize_action_parser() -> GraderParser:
     return parser
 
 
-def run_query(query_type: str, number_of_days: int):
+def run_query(query_type: str, number_of_days: int, output_json: bool):
     """
     Run the query specified by query_type.
 
     :param query_type: type of the query
+    :param number_of_days: specifies the number of days to use when querying
+      for recent assignments
+    :param output_json: whether or not to print output as JSON
     """
 
     if query_type == 'classes':
-        list_classes()
+        list_classes(output_json)
     elif query_type == 'assignments':
-        list_assignments()
+        list_assignments(output_json)
     elif query_type == 'students':
-        list_students()
+        list_students(output_json)
     elif query_type == 'recent':
-        list_recent(number_of_days)
+        list_recent(number_of_days, output_json)
 
 
 def main():
@@ -426,7 +431,8 @@ def take_action(parsed_args):
         fetch_submissions(class_name, assignment_name,
                           dest_path)
     elif action_name == 'query':
-        run_query(parsed_args.query_type, parsed_args.number_of_days)
+        run_query(parsed_args.query_type, parsed_args.number_of_days,
+                  parsed_args.json)
     elif action_name == 'trigger':
         trigger_tests(class_name, assignment_name,
                       parsed_args.student_usernames)

--- a/git-keeper-client/gkeepclient/queries.py
+++ b/git-keeper-client/gkeepclient/queries.py
@@ -152,6 +152,9 @@ def list_recent(number_of_days, output_json: bool):
         class_name_printed = False
 
         for assignment_name in sorted(info.assignment_list(class_name)):
+            if not info.is_published(class_name, assignment_name):
+                continue
+
             students_submitted = info.students_submitted_list(class_name,
                                                               assignment_name)
 

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from robot.utils.asserts import assert_equal
+
 from gkeeprobot.control.ClientControl import ClientControl
 from gkeeprobot.exceptions import GkeepRobotException
 from gkeeprobot.control.VMControl import ExitCodeException
@@ -73,7 +75,7 @@ class ClientCheckKeywords:
         import json
         pp_results = pprint.pformat(json.loads(results.strip()))
         pp_expected = pprint.pformat(json.loads(expected_results))
-        assert pp_results == pp_expected
+        assert_equal(pp_results, pp_expected)
 
     def gkeep_add_faculty_succeeds(self, admin, new_faculty):
         last_name = 'Professor'

--- a/tests/acceptance/gkeep_query.robot
+++ b/tests/acceptance/gkeep_query.robot
@@ -1,4 +1,4 @@
-# Copyright 2018 Nathan Sommer and Ben Coleman
+# Copyright 2019 Nathan Sommer and Ben Coleman
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,5 +42,4 @@ Class With Assignment Results in JSON
     Gkeep Query JSON Produces Results    faculty1   classes   ["cs1"]
     Gkeep Query JSON Produces Results    faculty1   assignments   {"cs1":[{"name":"good_simple","published":false}]}
     Gkeep Query JSON Produces Results    faculty1   students   {"cs1":[{"first_name":"First","last_name":"Last","username":"student1"}]}
-    Gkeep Query JSON Produces Results    faculty1   recent   {"cs1":{"good_simple":[]}}
-
+    Gkeep Query JSON Produces Results    faculty1   recent   {}


### PR DESCRIPTION
All gkeep queries now support the `--json` switch which will cause the output to be a JSON string representation of the query response. The JSON structure for the various queries is below.

Classes:
```json
[
    "class_one",
    "class_two"
]
```

Assignments:
```json
{
    "class_one": [
        {
            "name": "assignment_one",
            "published": true
        },
        {
            "name": "assignment_two",
            "published": false
        }
    ]
}
```

Students:
```json
{
    "class_one": [
        {
            "first_name": "Student",
            "last_name": "One",
            "username": "student_one"
        }
    ]
}
```

Recent submissions:
```json
{
    "class_one": {
        "assignment_one": [
            {
                "time": 1567067618,
                "human_time": "2019-08-29 04:33:38",
                "first_name": "Student",
                "last_name": "One",
                "username": "student_one"
            }
        ]
    }
}
```