### PR TITLE
Student submit

### DIFF
--- a/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
@@ -42,6 +42,12 @@ class ClientSetupKeywords:
                                           name,
                                           temp_dir_name)
 
+    def create_git_config(self, username):
+        name_cmd = 'git config --global user.name "{}"'.format(username)
+        client_control.run(username, name_cmd)
+        email_cmd = 'git config --global user.email {}@gitkeeper.edu'.format(username)
+        client_control.run(username, email_cmd)
+
     def add_to_class_csv(self, faculty, class_name, student):
         line = 'Last,First,{}@gitkeeper.edu'.format(student)
         client_control.run_vm_python_script(faculty, 'add_to_file.py',
@@ -78,3 +84,12 @@ class ClientSetupKeywords:
         url = '{}@gkserver:/home/{}/{}/{}/{}.git'.format(student, student, faculty, class_name, assignment_name)
         command = 'git clone {} assignments/{}'.format(url, assignment_name)
         client_control.run(student, command)
+
+    def student_submits_correct_solution(self, student, faculty, class_name, assignment_name):
+        assignment_folder = '~/assignments/{}'.format(assignment_name)
+        cp_cmd = 'cp /vagrant/assignments/{}/correct_solution/* {}'.format(assignment_name, assignment_folder)
+        client_control.run(student, cp_cmd)
+        commit_cmd = 'cd {}; git commit -am "done"'.format(assignment_folder)
+        client_control.run(student, commit_cmd)
+        push_cmd = 'cd {}; git push origin master'.format(assignment_folder)
+        client_control.run(student, push_cmd)

--- a/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
@@ -30,9 +30,9 @@ class ServerCheckKeywords:
         result = control.run_vm_python_script('keeper', 'server_terminated.py')
         assert result == 'True'
 
-    def email_exists(self, to_user, contains):
+    def email_exists(self, to_user, subject_contains=None, body_contains=None):
         result = control.run_vm_python_script('keeper', 'email_to.py',
-                                              to_user, contains)
+                                              to_user, subject_contains, body_contains)
         assert result == 'True'
 
     def email_does_not_exist(self, username):

--- a/git-keeper-robot/gkeeprobot/keywords/ServerWaitKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerWaitKeywords.py
@@ -26,9 +26,9 @@ class ServerWaitKeywords:
         result = control.run_vm_python_script('keeper', 'server_is_running.py')
         assert result == 'True'
 
-    def wait_for_email(self, to_user, contains):
+    def wait_for_email(self, to_user, subject_contains, body_contains):
         result = control.run_vm_python_script('keeper', 'email_to.py',
-                                              to_user, contains)
+                                              to_user, subject_contains, body_contains)
         assert result == 'True'
 
     def wait_for_user(self, username):

--- a/tests/acceptance/assignments/bad_action/base_code/code.py
+++ b/tests/acceptance/assignments/bad_action/base_code/code.py
@@ -1,0 +1,3 @@
+
+def go():
+    pass

--- a/tests/acceptance/assignments/bad_action/correct_solution/code.py
+++ b/tests/acceptance/assignments/bad_action/correct_solution/code.py
@@ -1,0 +1,3 @@
+
+def go():
+    return

--- a/tests/acceptance/assignments/bad_action/email.txt
+++ b/tests/acceptance/assignments/bad_action/email.txt
@@ -1,0 +1,1 @@
+good_simple assignment

--- a/tests/acceptance/assignments/bad_action/tests/action.sh
+++ b/tests/acceptance/assignments/bad_action/tests/action.sh
@@ -1,0 +1,3 @@
+
+echo 'Done'
+exit 1

--- a/tests/acceptance/assignments/good_simple/correct_solution/code.py
+++ b/tests/acceptance/assignments/good_simple/correct_solution/code.py
@@ -1,0 +1,3 @@
+
+def go():
+    return

--- a/tests/acceptance/assignments/good_simple2/email.txt
+++ b/tests/acceptance/assignments/good_simple2/email.txt
@@ -1,1 +1,1 @@
-good_simple assignment
+good_simple2 assignment

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -34,8 +34,8 @@ Valid Class
     Gkeep Add Succeeds    faculty=faculty1    class_name=cs1
     User Exists On Server    student1
     User Exists On Server    student2
-    Email Exists    to_user=student1    contains=Password
-    Email Exists    to_user=student2    contains=Password
+    Email Exists    to_user=student1    subject_contains="New git-keeper account"    body_contains=Password
+    Email Exists    to_user=student2    subject_contains="New git-keeper account"    body_contains=Password
     Gkeep Query Contains    faculty1    classes    cs1
     Gkeep Query Contains    faculty1    students    student1    student2
 
@@ -51,7 +51,7 @@ Existing Student
     Gkeep Add Succeeds    faculty=faculty1    class_name=cs1
     User Exists On Server    student1
     User Exists On Server    student2
-    Email Exists    to_user=student1    contains=Password
+    Email Exists    to_user=student1    subject_contains="New git-keeper account"    body_contains=Password
     Email Does Not Exist    to_user=student2
     Gkeep Query Contains    faculty1    classes    cs1
     Gkeep Query Contains    faculty1    students    student1    student2

--- a/tests/acceptance/gkeep_add_faculty.robot
+++ b/tests/acceptance/gkeep_add_faculty.robot
@@ -29,20 +29,20 @@ Force Tags    gkeep_add_faculty
 Add One Faculty
     [Tags]    happy_path
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    Email Exists    to_user=faculty1    contains=Password
+    Email Exists    to_user=faculty1    subject_contains="New git-keeper account"    body_contains=Password
     User Exists On Server    faculty1
 
 Duplicate Faculty
     [Tags]    error
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    Wait For Email      to_user=faculty1    contains=Password
+    Wait For Email      to_user=faculty1    subject_contains="New git-keeper account"    body_contains=Password
     Gkeep Add Faculty Fails    admin_prof    faculty1
     Gkeepd Is Running
 
 Add Faculty As Non Admin
     [Tags]    error
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    Wait For Email      to_user=faculty1    contains=Password
+    Wait For Email      to_user=faculty1    subject_contains="New git-keeper account"    body_contains=Password
     Create Accounts On Client    faculty1
     Gkeep Add Faculty Fails    faculty1    prof3
     Gkeepd Is Running

--- a/tests/acceptance/gkeep_modify.robot
+++ b/tests/acceptance/gkeep_modify.robot
@@ -32,7 +32,7 @@ Add Student
     Add To Class CSV    faculty=faculty1    class_name=cs1    student=student3
     Gkeep Modify Succeeds    faculty=faculty1    class_name=cs1
     User Exists On Server    student3
-    Email Exists    to_user=student3    contains=Password
+    Email Exists    to_user=student3    subject_contains="New git-keeper account"    body_contains=Password
     Gkeep Query Contains    faculty1    students    student3
 
 Remove Student

--- a/tests/acceptance/gkeep_publish.robot
+++ b/tests/acceptance/gkeep_publish.robot
@@ -33,8 +33,8 @@ Setup Server and Client Accounts
 Valid Assignment Publish
     [Tags]  happy_path
     Gkeep Publish Succeeds  faculty1    cs1     good_simple
-    Email Exists    student1    good_simple
-    Email Exists    student2    good_simple
+    Email Exists    student1    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
+    Email Exists    student2    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
     Clone Assignment  student1  faculty1    cs1     good_simple
     Clone Assignment  student2  faculty1    cs1     good_simple
 
@@ -56,14 +56,14 @@ Double Upload Then Double Publish
     Gkeep Upload Succeeds   faculty1   cs1    good_simple2
     # Publish 1st assignment
     Gkeep Publish Succeeds  faculty1    cs1     good_simple
-    Email Exists    student1    good_simple
-    Email Exists    student2    good_simple
+    Email Exists    student1    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
+    Email Exists    student2    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
     Clone Assignment  student1  faculty1    cs1     good_simple
     Clone Assignment  student2  faculty1    cs1     good_simple
     # Publish 2nd assignment
     Gkeep Publish Succeeds  faculty1    cs1     good_simple2
-    Email Exists    student1    good_simple2
-    Email Exists    student2    good_simple2
+    Email Exists    student1    subject_contains="[cs1] New assignment: good_simple2"    body_contains=good_simple2
+    Email Exists    student2    subject_contains="[cs1] New assignment: good_simple2"    body_contains=good_simple2
     Clone Assignment  student1  faculty1    cs1     good_simple2
     Clone Assignment  student2  faculty1    cs1     good_simple2
 
@@ -73,13 +73,13 @@ Interleave Upload and Publish
     Gkeep Upload Succeeds   faculty1   cs1    good_simple2
     # Publish 2nd assignment
     Gkeep Publish Succeeds  faculty1    cs1     good_simple2
-    Email Exists    student1    good_simple2
-    Email Exists    student2    good_simple2
+    Email Exists    student1    subject_contains="[cs1] New assignment: good_simple2"    body_contains=good_simple2
+    Email Exists    student2    subject_contains="[cs1] New assignment: good_simple2"    body_contains=good_simple2
     Clone Assignment  student1  faculty1    cs1     good_simple2
     Clone Assignment  student2  faculty1    cs1     good_simple2
     # Publish 1st assignment
     Gkeep Publish Succeeds  faculty1    cs1     good_simple
-    Email Exists    student1    good_simple
-    Email Exists    student2    good_simple
+    Email Exists    student1    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
+    Email Exists    student2    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
     Clone Assignment  student1  faculty1    cs1     good_simple
     Clone Assignment  student2  faculty1    cs1     good_simple

--- a/tests/acceptance/gkeep_upload.robot
+++ b/tests/acceptance/gkeep_upload.robot
@@ -31,7 +31,7 @@ Valid Assignment Upload
     [Tags]  happy_path
     Add Assignment to Client  faculty1  good_simple
     Gkeep Upload Succeeds   faculty1   cs1    good_simple
-    Email Exists  faculty1    good_simple
+    Email Exists  faculty1    subject_contains="[cs1] New assignment: good_simple"    body_contains=good_simple
     Clone Assignment    faculty1  faculty1  cs1  good_simple
     gkeep query contains  faculty1    assignments  U good_simple
 

--- a/tests/acceptance/gkeepd_launch.robot
+++ b/tests/acceptance/gkeepd_launch.robot
@@ -25,7 +25,7 @@ Valid Setup
     [Tags]    happy_path
     Add File To Server    keeper    files/valid_server.cfg    server.cfg
     Start gkeepd
-    Email Exists    to_user=admin_prof    contains=Password
+    Email Exists    to_user=admin_prof    subject_contains="New git-keeper account"    body_contains=Password
     User Exists On Server    admin_prof
     User Exists On Server   tester
     Gkeepd Is Running

--- a/tests/acceptance/manual_configure.py
+++ b/tests/acceptance/manual_configure.py
@@ -16,10 +16,12 @@
 from gkeeprobot.control.VagrantControl import VagrantControl
 from gkeeprobot.keywords.ServerSetupKeywords import ServerSetupKeywords
 from gkeeprobot.keywords.ClientSetupKeywords import ClientSetupKeywords
+from gkeeprobot.keywords.ClientCheckKeywords import ClientCheckKeywords
 
 vagrant = VagrantControl()
 server = ServerSetupKeywords()
 client = ClientSetupKeywords()
+client_check = ClientCheckKeywords()
 
 print('Checking that gkserver is running')
 if not vagrant.is_server_running():
@@ -55,4 +57,17 @@ client.add_to_class_csv('prof1', 'cs1', 'student2')
 client.run_gkeep_command('prof1', 'add cs1 cs1.csv')
 client.add_assignment_to_client('prof1', 'good_simple')
 
+print('Making student1 and student2 accounts on gkclient')
+client.create_account('student1')
+client.establish_ssh_keys('student1')
+client.create_git_config('student1')
+client.create_account('student2')
+client.establish_ssh_keys('student2')
+client.create_git_config('student2')
 
+print('Prof1 Uploads and Publishes Assignment')
+client_check.gkeep_upload_succeeds('prof1', 'cs1', 'good_simple')
+client_check.gkeep_publish_succeeds('prof1', 'cs1', 'good_simple')
+
+print('Student1 Clones Assignment')
+client.clone_assignment('student1', 'prof1', 'cs1', 'good_simple')

--- a/tests/acceptance/resources/setup.robot
+++ b/tests/acceptance/resources/setup.robot
@@ -26,7 +26,7 @@ Add Faculty and Configure Accounts on Client
     [Arguments]    @{faculty_names}
     :FOR    ${username}    IN    @{faculty_names}
     \        Gkeep Add Faculty Succeeds    admin_prof    ${username}
-    \        Wait For Email    to_user=${username}    contains=Password
+    \        Wait For Email    to_user=${username}    subject_contains="New git-keeper account"    body_contains=Password
     Create Accounts On Client  @{faculty_names}
 
 Launch Gkeepd And Configure Admin Account on Client
@@ -35,7 +35,7 @@ Launch Gkeepd And Configure Admin Account on Client
     Add File To Server    keeper    files/valid_server.cfg    server.cfg
     Start gkeepd
     Wait For Gkeepd
-    Wait For Email    to_user=admin_prof    contains=Password
+    Wait For Email    to_user=admin_prof    subject_contains="New git-keeper account"    body_contains=Password
     Create Accounts On Client    admin_prof
 
 Establish Course

--- a/tests/acceptance/student_submit.robot
+++ b/tests/acceptance/student_submit.robot
@@ -1,0 +1,51 @@
+# Copyright 2018 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+*** Settings ***
+Resource    resources/setup.robot
+Test Setup    Setup Server and Client Accounts
+Force Tags    gkeepd_launch
+
+*** Keywords ***
+
+Setup Server and Client Accounts
+    Launch Gkeepd And Configure Admin Account on Client
+    Add Faculty and Configure Accounts on Client    faculty1
+    Establish Course  faculty1    cs1     student1
+    Create Accounts On Client    student1
+    Create Git Config    student1
+
+*** Test Cases ***
+
+Student Submits Correct Solution
+    [Tags]  happy_path
+    Add Assignment to Client  faculty1  good_simple
+    Gkeep Upload Succeeds   faculty1   cs1    good_simple
+    Gkeep Publish Succeeds  faculty1    cs1     good_simple
+    Clone Assignment  student1  faculty1    cs1     good_simple
+    Student Submits Correct Solution    student1    faculty1    cs1    good_simple
+    Email Exists    student1    "[cs1] good_simple submission test results"
+
+Bad Action.sh
+    [Tags]  error
+    Add Assignment to Client  faculty1  bad_action
+    Gkeep Upload Succeeds   faculty1   cs1    bad_action
+    Gkeep Publish Succeeds  faculty1    cs1     bad_action
+    Clone Assignment  student1  faculty1    cs1     bad_action
+    Student Submits Correct Solution    student1    faculty1    cs1    bad_action
+    Email Exists    student1    "bad_action: Failed to process submission - contact instructor"
+
+

--- a/tests/acceptance/student_submit.robot
+++ b/tests/acceptance/student_submit.robot
@@ -37,7 +37,7 @@ Student Submits Correct Solution
     Gkeep Publish Succeeds  faculty1    cs1     good_simple
     Clone Assignment  student1  faculty1    cs1     good_simple
     Student Submits Correct Solution    student1    faculty1    cs1    good_simple
-    Email Exists    student1    "[cs1] good_simple submission test results"
+    Email Exists    student1    subject_contains="[cs1] good_simple submission test results"    body_contains="Done"
 
 Bad Action.sh
     [Tags]  error
@@ -46,6 +46,6 @@ Bad Action.sh
     Gkeep Publish Succeeds  faculty1    cs1     bad_action
     Clone Assignment  student1  faculty1    cs1     bad_action
     Student Submits Correct Solution    student1    faculty1    cs1    bad_action
-    Email Exists    student1    "bad_action: Failed to process submission - contact instructor"
+    Email Exists    student1    subject_contains="bad_action: Failed to process submission - contact instructor"    body_contains="instructor"
 
 

--- a/tests/acceptance/vm_scripts/email_to.py
+++ b/tests/acceptance/vm_scripts/email_to.py
@@ -20,12 +20,25 @@ import sys
 
 
 @polling
-def email(to, contains):
+def email(to, subject_contains=None, body_contains=None):
     for file in glob.glob('/email/{}_*.txt'.format(to)):
-        with open(file) as f:
-            if contains in f.read():
-                return True
+        if check_email_contains(file, subject_contains=subject_contains, body_contains=body_contains):
+            return True
     return False
 
+def check_email_contains(filename, subject_contains=None, body_contains=None):
+    with open(filename) as f:
+        from_line = f.readline()
+        subject_line = f.readline()
+        body = f.read()
 
-print(email(sys.argv[1], sys.argv[2]))
+        if subject_contains is not None and subject_contains not in subject_line:
+            return False
+
+        if body_contains is not None and body_contains not in body:
+            return False
+
+        return True
+
+
+print(email(sys.argv[1], subject_contains=sys.argv[2], body_contains=sys.argv[3]))


### PR DESCRIPTION

Adds tests for students submitting:

* When the `action.sh` succeeds
* When the `action.sh` fails

I realized that we don't really need to test whether the student submission correct or not - that is what the faculty member has to write in `action.sh`.

When I was working on this, I realized that the `Email Exists` process was clunky, and so I changed it to explicitly talk about subjects and bodies.  This cascaded into a ton of files, but those changes are consistent.
