### PR TITLE
Ensure unique reports filenames

### DIFF
--- a/git-keeper-server/gkeepserver/submission.py
+++ b/git-keeper-server/gkeepserver/submission.py
@@ -163,6 +163,14 @@ class Submission:
                 report_file_path = os.path.join(student_report_dir_path,
                                                 report_filename)
 
+                counter = 1
+                while os.path.exists(report_file_path):
+                    report_filename = 'report-{0}-{1}.txt'.format(timestamp,
+                                                                  counter)
+                    report_file_path = os.path.join(student_report_dir_path,
+                                                    report_filename)
+                    counter += 1
+
                 with open(report_file_path, 'w') as f:
                     f.write(body)
 


### PR DESCRIPTION
When adding a report to a student's reports directory, there is a chance
that the filename already exists if both submissions are processed
within the same second. If this is the case, a number is added
to the filename to make it unique.