### PR TITLE
Update acceptance test VMs to use ubuntu/bionic64

### DIFF
--- a/tests/acceptance/gkclient_base/Vagrantfile
+++ b/tests/acceptance/gkclient_base/Vagrantfile
@@ -15,7 +15,7 @@
 
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "ubuntu/bionic64"
     config.vm.provision "shell", inline:<<-SCRIPT
         useradd -ms /bin/bash keeper
         usermod -aG keeper keeper

--- a/tests/acceptance/gkserver_base/Vagrantfile
+++ b/tests/acceptance/gkserver_base/Vagrantfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "ubuntu/bionic64"
     config.vm.provision "shell", inline:<<-SCRIPT
         useradd -ms /bin/bash keeper
         usermod -aG keeper keeper

--- a/tests/acceptance/gkserver_base/mysmtpd.py
+++ b/tests/acceptance/gkserver_base/mysmtpd.py
@@ -50,12 +50,13 @@ class MySMTPD(smtpd.DebuggingServer):
         :return: None
         """
 
-        smtpd.DebuggingServer.__init__(self, ('localhost', port), None)
+        smtpd.DebuggingServer.__init__(self, ('localhost', port), None,
+                                       decode_data=True)
         self.directory = directory
 
         self.users = {}
 
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         """
         Process one message (save it to the appropriate file
 

--- a/tests/acceptance/vm_scripts/reset_client.py
+++ b/tests/acceptance/vm_scripts/reset_client.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gkeepcore.shell_command import run_command
+from gkeepcore.shell_command import run_command, CommandError
 
 
 def remove_users():
@@ -23,6 +23,11 @@ def remove_users():
 
     for user in os.listdir('/home'):
         if user not in expected:
+            try:
+                run_command('sudo pkill -9 -u {}'.format(user))
+            except CommandError:
+                pass
+
             run_command('sudo userdel -r {}'.format(user))
 
 

--- a/tests/acceptance/vm_scripts/reset_server.py
+++ b/tests/acceptance/vm_scripts/reset_server.py
@@ -58,6 +58,11 @@ def remove_users():
 
     for user in os.listdir('/home'):
         if user not in expected:
+            try:
+                run_command('sudo pkill -9 -u {}'.format(user))
+            except CommandError:
+                pass
+
             run_command('sudo userdel -r {}'.format(user))
 
 


### PR DESCRIPTION
The primary motivation for this change was to bring the Python version
up to 3.6, since the cryptography package will soon no longer support
Python 3.5, the version used by ubuntu/xenial64.

Python 3.6 brought changes to smtpd.DebuggingServer, meaning mysmtpd.py
had to be changed accordingly.

After the update, tests were occasionally failing when resetting the
client and trying to delete user accounts. This was due to lingering
processes. reset_client.py and reset_server.py now use pkill to kill
all processes owned by the user that is about to be deleted.