### PR TITLE
Reduce the priority of bulk emails in the email queue

### DIFF
--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -37,7 +37,7 @@ from gkeepcore.system_commands import cp, chmod, mkdir, sudo_chown, rm, mv
 from gkeepserver.database import db
 from gkeepserver.email_sender_thread import email_sender
 from gkeepserver.server_configuration import config
-from gkeepserver.server_email import Email, EmailException
+from gkeepserver.server_email import Email, EmailException, EmailPriority
 
 
 class StudentAssignmentError(GkeepException):
@@ -442,9 +442,15 @@ def setup_student_assignment(assignment_dir: AssignmentDirectory,
     # clone URL followed by email.txt contents
     email_body = 'Clone URL:\n{0}\n\n{1}'.format(clone_url, email_body)
 
+    if student.username != faculty_username:
+        priority = EmailPriority.LOW
+    else:
+        priority = EmailPriority.HIGH
+
     # build the email
     try:
-        email = Email(student.email_address, email_subject, email_body)
+        email = Email(student.email_address, email_subject, email_body,
+                      priority=priority)
     except EmailException as e:
         raise StudentAssignmentError(e)
 

--- a/git-keeper-server/gkeepserver/create_user.py
+++ b/git-keeper-server/gkeepserver/create_user.py
@@ -34,7 +34,7 @@ from gkeepserver.gkeepd_logger import gkeepd_logger as logger, gkeepd_logger
 from gkeepserver.initialize_log import initialize_log
 from gkeepserver.log_polling import log_poller
 from gkeepserver.server_configuration import config
-from gkeepserver.server_email import Email
+from gkeepserver.server_email import Email, EmailPriority
 
 
 class UserType(Enum):
@@ -215,7 +215,13 @@ def create_user(username, user_type, first_name, last_name, email_address=None,
 
         body += 'Enjoy!'
 
-        email_sender.enqueue(Email(email_address, subject, body))
+        if user_type == UserType.student:
+            email_priority = EmailPriority.LOW
+        else:
+            email_priority = EmailPriority.NORMAL
+
+        email_sender.enqueue(Email(email_address, subject, body,
+                                   priority=email_priority))
 
 
 def create_student_user(student: Student):

--- a/git-keeper-server/gkeepserver/email_sender_thread.py
+++ b/git-keeper-server/gkeepserver/email_sender_thread.py
@@ -93,7 +93,7 @@ class EmailSenderThread(Thread):
         :param email: the email to send
         """
 
-        self._email_queue.put((email.priority, email))
+        self._email_queue.put(email)
 
     def shutdown(self):
         """
@@ -122,20 +122,14 @@ class EmailSenderThread(Thread):
         while not self._shutdown_flag:
             try:
                 while True:
-                    payload = self._email_queue.get(block=True, timeout=0.1)
+                    email = self._email_queue.get(block=True, timeout=0.1)
 
-                    try:
-                        priority, email = payload
-                        if not isinstance(email, Email):
-                            warning = ('Item dequeued for emailing that is '
-                                       'not an email: {0}'.format(email))
-                            logger.log_warning(warning)
-                        else:
-                            self._send_email_with_rate_limiting(email)
-                    except ValueError:
-                        warning = ('Email queue contained an object that '
-                                   'was not a (priority, email) tuple')
+                    if not isinstance(email, Email):
+                        warning = ('Item dequeued for emailing that is '
+                                   'not an email: {0}'.format(email))
                         logger.log_warning(warning)
+                    else:
+                        self._send_email_with_rate_limiting(email)
             except Empty:
                 pass
             except Exception as e:

--- a/git-keeper-server/gkeepserver/server_email.py
+++ b/git-keeper-server/gkeepserver/server_email.py
@@ -121,6 +121,10 @@ class Email:
                                                      self._subject)
         return repr_string
 
+    def __lt__(self, other):
+        # Provide < comparison for use by the PriorityQueue
+        return self.priority < other.priority
+
     def _build_mime_message(self, files_to_attach):
         # Create the final message by building up a MIMEMultipart object and
         # then storing the final message as a string in _message_string

--- a/git-keeper-server/gkeepserver/server_email.py
+++ b/git-keeper-server/gkeepserver/server_email.py
@@ -29,6 +29,7 @@ from email.header import Header
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from enum import IntEnum
 from smtplib import SMTP
 
 from gkeepcore.gkeep_exception import GkeepException
@@ -40,13 +41,23 @@ class EmailException(GkeepException):
     pass
 
 
+class EmailPriority(IntEnum):
+    """
+    Enum used to specify an email's priority level for use by the priority
+    queue in the email sending thread.
+    """
+    NORMAL = 2
+    URGENT = 1
+    EXTREME = 0
+
+
 class Email:
     """
     Builds an email that can be sent using smtplib and provides a method
     to send the email.
     """
     def __init__(self, to_address, subject, body, files_to_attach=None,
-                 max_character_count=1000000):
+                 max_character_count=1000000, priority=EmailPriority.NORMAL):
         """
         Construct an email object.
 
@@ -60,6 +71,8 @@ class Email:
         :param files_to_attach: a list of file paths to attach to the email
         :param max_character_count: if the email is longer than this number of
          characters it will be truncated
+        :param priority: an EmailPriority representing the email's priority
+         in the send queue
         """
 
         self._send_attempts = 0
@@ -70,6 +83,8 @@ class Email:
 
         self._subject = subject
         self._files_to_attach = files_to_attach
+
+        self.priority = priority
 
         # regardless of how the body is passed in, represent it by a list of
         # lines that have trailing whitespace removed

--- a/git-keeper-server/gkeepserver/server_email.py
+++ b/git-keeper-server/gkeepserver/server_email.py
@@ -46,9 +46,9 @@ class EmailPriority(IntEnum):
     Enum used to specify an email's priority level for use by the priority
     queue in the email sending thread.
     """
-    NORMAL = 2
-    URGENT = 1
-    EXTREME = 0
+    LOW = 2
+    NORMAL = 1
+    HIGH = 0
 
 
 class Email:


### PR DESCRIPTION
Adding a new class roster and publishing an assignment both cause
a batch of emails to be added to the sending queue. Since email
sending is rate limited, other emails will be delayed. This patch
lowers the priority of new account emails and new assignment
emails, but only for students. This increases the responsiveness
for actions where a single email is expected right away, such as
test results and new assignment emails that go to faculty upon
uploading.