### PR TITLE
Fix email about disabled assignment

### DIFF
--- a/git-keeper-server/gkeepserver/event_handlers/disable_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/disable_handler.py
@@ -73,7 +73,8 @@ class DisableHandler(EventHandler):
                              .format(self._class_name, self._assignment_name))
             email_body = ('Assignment {} in class {} has been disabled. '
                           'No tests will be run if you push to your '
-                          'repository for this assignment.')
+                          'repository for this assignment.\n'
+                          .format(self._assignment_name, self._class_name))
             for student in db.get_class_students(self._class_name,
                                                  self._faculty_username):
                 email_sender.enqueue(Email(student.email_address,


### PR DESCRIPTION
Previously the names of the assignment and the class were not actually inserted
into the body of the email about a disabled assignment.