### PR TITLE
Remove dependency on "master" as default branch name

### DIFF
--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -87,7 +87,21 @@ def git_commit(repo_path, message):
     run_command_in_directory(repo_path, cmd)
 
 
-def git_push(repo_path, dest=None, branch='master', force=False, sudo=False):
+def get_git_branch(repo_path):
+    """
+    Get the current branch of a git repository.
+
+    :param repo_path: path of the repository
+    :return: name of the current branch
+    """
+
+    cmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
+    branch = run_command_in_directory(repo_path, cmd).strip()
+
+    return branch
+
+
+def git_push(repo_path, dest=None, branch=None, force=False, sudo=False):
     """
     Push a repository to its upstream remote, or to a specific destination.
 
@@ -105,6 +119,9 @@ def git_push(repo_path, dest=None, branch='master', force=False, sudo=False):
         cmd.append('-f')
 
     if dest is not None:
+        if branch is None:
+            branch = get_git_branch(repo_path)
+
         cmd += [dest, branch]
 
     run_command_in_directory(repo_path, cmd, sudo=sudo)

--- a/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
@@ -16,6 +16,7 @@
 
 from gkeeprobot.control.ClientControl import ClientControl
 from gkeeprobot.control.ServerControl import ServerControl
+from gkeeprobot.control.VMControl import ExitCodeException
 
 """Provides keywords for robotframework to configure faculty and student
 accounts before testing begins."""
@@ -95,6 +96,20 @@ class ClientSetupKeywords:
         client_control.run(student, commit_cmd)
         push_cmd = 'cd {}; git push origin master'.format(assignment_folder)
         client_control.run(student, push_cmd)
+
+    def student_submits_different_branch(self, student, class_name, assignment_name):
+        assignment_folder = '~/assignments/{}/{}'.format(class_name, assignment_name)
+        cp_cmd = 'cp /vagrant/assignments/{}/correct_solution/* {}'.format(assignment_name, assignment_folder)
+        client_control.run(student, cp_cmd)
+        new_branch_cmd = 'cd {}; git checkout -b other'.format(assignment_folder)
+        client_control.run(student, new_branch_cmd)
+        commit_cmd = 'cd {}; git commit -am "done"'.format(assignment_folder)
+        client_control.run(student, commit_cmd)
+        push_cmd = 'cd {}; git push origin other'.format(assignment_folder)
+        try:
+            client_control.run(student, push_cmd)
+        except ExitCodeException:
+            pass
 
     def fetch_assignment(self, faculty, class_name, assignment_name, target_dir=None):
         if target_dir is not None:

--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -189,7 +189,7 @@ def create_base_code_repo(assignment_dir: AssignmentDirectory,
     Create a bare repository in an assignment directory which contains the
     base code for an assignment, a post-receive hook script for triggering
     tests, and a pre-receive hook for ensuring the students only push to
-    the master branch. The repository is configured to reject destructive
+    the one existing branch. The repository is configured to reject destructive
     pushes.
 
     Raises an AssignmentDirectoryError if anything goes wrong.

--- a/git-keeper-server/gkeepserver/data/pre-receive
+++ b/git-keeper-server/gkeepserver/data/pre-receive
@@ -15,13 +15,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-# This hook prevents students from pushing to a branch other than master.
+# This hook prevents students from pushing to a branch other than the one
+# existing branch.
 #
 # If this script exits with a 0 exit code the push is accepted, otherwise the
 # push is rejected.
 
-# we will only allow pushes to the master branch
-allowed_ref='refs/heads/master'
+# get the ref and name of the existing branch
+allowed_ref=$(git symbolic-ref HEAD)
+allowed_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 
 # this hook receives push information about each ref that is pushed in the
 # form <old hash> <new hash> <ref name>
@@ -29,7 +31,7 @@ while read old_hash new_hash ref_name
 do
     if [ $ref_name != $allowed_ref ]
     then
-        echo "ERROR: You may only push to the master branch"
+        echo "ERROR: You may only push to the $allowed_branch branch"
         exit 1
     fi
 done

--- a/tests/acceptance/student_submit.robot
+++ b/tests/acceptance/student_submit.robot
@@ -39,6 +39,15 @@ Student Submits Correct Solution
     Student Submits Correct Solution    student1    faculty1    cs1    good_simple
     Submission Test Results Email Exists    student1    cs1    good_simple    Done
 
+Student Submit From Other Branch
+    [Tags]  error
+    Add Assignment to Client  faculty1  good_simple
+    Gkeep Upload Succeeds   faculty1   cs1    good_simple
+    Gkeep Publish Succeeds  faculty1    cs1     good_simple
+    Clone Assignment  student1  faculty1    cs1     good_simple
+    Student Submits Different Branch    student1    cs1     good_simple
+    Submission Test Results Email Does Not Exist    student1    cs1     good_simple     Done
+
 Student Submits Python Action Solution
     [Tags]  happy_path
     Add Assignment to Client  faculty1  good_action_py


### PR DESCRIPTION
With GitHub changing the default branch name of new repositories from
"master" to "main" it is conceivable that git itself might do the same
in the future, or that we want to change the default branch name in
git-keeper.  This commit removes the dependency on the default branch
name being "master" in two ways:

- Previously there was a pre-receive hook on assignment repositories
  explicitly preventing students from pushing to a branch other than
  master. Now it prevents pushing to a branch other than the one
  existing branch, whatever it may be named.
- Previously the git_push() function assumed pushing to the master
  branch when a destination repository was specified. Now the branch
  to push is the currently checked out branch, unless one is provided
  by the caller.