### PR TITLE
Write run_action.sh just before testing a submission

### DIFF
--- a/git-keeper-server/gkeepserver/event_handlers/update_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/update_handler.py
@@ -30,7 +30,7 @@ from gkeepcore.upload_directory import UploadDirectory
 from gkeepserver.assignments import AssignmentDirectory, \
     create_base_code_repo, copy_email_txt_file, \
     copy_tests_dir, remove_student_assignment, setup_student_assignment, \
-    StudentAssignmentError, write_run_action_sh
+    StudentAssignmentError
 from gkeepserver.database import db
 from gkeepserver.event_handler import EventHandler, HandlerException
 from gkeepserver.gkeepd_logger import gkeepd_logger
@@ -143,8 +143,6 @@ class UpdateHandler(EventHandler):
 
             rm(assignment_dir.tests_path, recursive=True)
             copy_tests_dir(assignment_dir, upload_dir.tests_path)
-
-            write_run_action_sh(assignment_dir, upload_dir)
 
         # sanity check
         assignment_dir.check()

--- a/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
@@ -32,8 +32,7 @@ from gkeepcore.upload_directory import UploadDirectory, UploadDirectoryError
 from gkeepcore.valid_names import validate_assignment_name
 from gkeepserver.assignments import AssignmentDirectory, \
     AssignmentDirectoryError, create_base_code_repo, copy_email_txt_file, \
-    copy_tests_dir, setup_student_assignment, StudentAssignmentError, \
-    write_run_action_sh
+    copy_tests_dir, setup_student_assignment, StudentAssignmentError
 from gkeepserver.database import db
 from gkeepserver.event_handler import EventHandler, HandlerException
 from gkeepserver.gkeepd_logger import gkeepd_logger
@@ -166,8 +165,6 @@ class UploadHandler(EventHandler):
         except GkeepException as e:
             error = ('error copying assignment files: {0}'.format(str(e)))
             raise HandlerException(error)
-
-        write_run_action_sh(assignment_dir, upload_dir)
 
         # set permissions on assignment directory
         try:


### PR DESCRIPTION
Previously run_action.sh was written on upload or update, which
meant that if the global timeout or memory limit changed, the
tests would not use the new settings.