### PR TITLE
Log all gkeepd messages to standard output

### DIFF
--- a/git-keeper-server/gkeepserver/event_handlers/class_status_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/class_status_handler.py
@@ -44,11 +44,6 @@ class ClassStatusHandler(EventHandler):
             raise HandlerException('Invalid status for CLASS_STATUS: {}'
                                    .format(self._status))
 
-        print('Handling class status:')
-        print(' Faculty:', self._faculty_username)
-        print(' Class:  ', self._class_name)
-        print(' Status: ', self._status)
-
         try:
             if self._status == 'open':
                 db.open_class(self._class_name, self._faculty_username)

--- a/git-keeper-server/gkeepserver/event_handlers/delete_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/delete_handler.py
@@ -51,12 +51,6 @@ class DeleteHandler(EventHandler):
                                                       self._assignment_name,
                                                       gitkeeper_path)
 
-        print('Handling delete:')
-        print(' Faculty:        ', self._faculty_username)
-        print(' Class:          ', self._class_name)
-        print(' Assignment:     ', self._assignment_name)
-        print(' Assignment path:', assignment_path)
-
         try:
             if db.is_published(self._class_name, self._assignment_name,
                                self._faculty_username):

--- a/git-keeper-server/gkeepserver/event_handlers/disable_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/disable_handler.py
@@ -51,12 +51,6 @@ class DisableHandler(EventHandler):
                                                       self._assignment_name,
                                                       gitkeeper_path)
 
-        print('Handling disable:')
-        print(' Faculty:        ', self._faculty_username)
-        print(' Class:          ', self._class_name)
-        print(' Assignment:     ', self._assignment_name)
-        print(' Assignment path:', assignment_path)
-
         try:
             if not db.is_published(self._class_name, self._assignment_name,
                                    self._faculty_username):

--- a/git-keeper-server/gkeepserver/event_handlers/publish_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/publish_handler.py
@@ -58,12 +58,6 @@ class PublishHandler(EventHandler):
                                                       self._assignment_name,
                                                       gitkeeper_path)
 
-        print('Handling publish:')
-        print(' Faculty:        ', self._faculty_username)
-        print(' Class:          ', self._class_name)
-        print(' Assignment:     ', self._assignment_name)
-        print(' Assignment path:', assignment_path)
-
         try:
             if not db.class_is_open(self._class_name, self._faculty_username):
                 raise HandlerException(

--- a/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/submission_handler.py
@@ -38,15 +38,6 @@ class SubmissionHandler(EventHandler):
     def handle(self):
         """Take action after a student pushes a new submission."""
 
-        print('Handling submission:')
-        print(' Student:    ', self._student_username)
-        print(' Faculty:    ', self._faculty_username)
-        print(' Class:      ', self._class_name)
-        print(' Assignment: ', self._assignment_name)
-        print(' Repo path:  ', self._submission_repo_path)
-        print(' Commit hash:', self._commit_hash)
-        print()
-
         # We need to create a submission object to put in the
         # new_submission_queue.  This requires a Student object and
         # paths to student repo, tests (not a repo), and reports repo.

--- a/git-keeper-server/gkeepserver/event_handlers/trigger_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/trigger_handler.py
@@ -47,12 +47,6 @@ class TriggerHandler(EventHandler):
                                                       self._assignment_name,
                                                       gitkeeper_path)
 
-        print('Handling trigger:')
-        print(' Faculty:        ', self._faculty_username)
-        print(' Class:          ', self._class_name)
-        print(' Assignment:     ', self._assignment_name)
-        print(' Students:       ', self._student_usernames)
-
         try:
             assignment_dir = AssignmentDirectory(assignment_path)
 

--- a/git-keeper-server/gkeepserver/event_handlers/update_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/update_handler.py
@@ -58,13 +58,6 @@ class UpdateHandler(EventHandler):
                                                       self._assignment_name,
                                                       gitkeeper_path)
 
-        print('Handling update:')
-        print(' Faculty:        ', self._faculty_username)
-        print(' Class:          ', self._class_name)
-        print(' Assignment:     ', self._assignment_name)
-        print(' Path:           ', self._upload_path)
-        print(' Assignment path:', assignment_path)
-
         if db.is_disabled(self._class_name, self._assignment_name,
                           self._faculty_username):
             error = ('Assignment {} in class {} is disabled and '

--- a/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/upload_handler.py
@@ -60,13 +60,6 @@ class UploadHandler(EventHandler):
                                                       self._assignment_name,
                                                       gitkeeper_path)
 
-        print('Handling upload:')
-        print(' Faculty:        ', self._faculty_username)
-        print(' Class:          ', self._class_name)
-        print(' Assignment:     ', self._assignment_name)
-        print(' Path:           ', self._upload_path)
-        print(' Assignment path:', assignment_path)
-
         assignment_dir = AssignmentDirectory(assignment_path, check=False)
 
         try:

--- a/git-keeper-server/gkeepserver/gkeepd_logger.py
+++ b/git-keeper-server/gkeepserver/gkeepd_logger.py
@@ -168,6 +168,7 @@ class GkeepdLoggerThread(Thread):
             # Replace newlines in text with spaces so the entire log text is on
             # one line
             text = text.replace('\n', ' ')
+            print('{}: {}'.format(log_level.name, text))
             command = log_append_command(self._log_file_path,
                                          log_level.name, text,
                                          human_readable=True)

--- a/git-keeper-server/gkeepserver/gkeepd_logger.py
+++ b/git-keeper-server/gkeepserver/gkeepd_logger.py
@@ -168,7 +168,7 @@ class GkeepdLoggerThread(Thread):
             # Replace newlines in text with spaces so the entire log text is on
             # one line
             text = text.replace('\n', ' ')
-            print('{}: {}'.format(log_level.name, text))
+            print('{}: {}'.format(log_level.name, text), flush=True)
             command = log_append_command(self._log_file_path,
                                          log_level.name, text,
                                          human_readable=True)

--- a/git-keeper-server/gkeepserver/info_update_thread.py
+++ b/git-keeper-server/gkeepserver/info_update_thread.py
@@ -266,7 +266,6 @@ class InfoUpdateThread(Thread):
 
         try:
             if payload.instruction == InfoInstruction.FULL_SCAN:
-                logger.log_info(str(type(payload)))
                 self._full_scan(payload.faculty_username)
 
             elif payload.instruction == InfoInstruction.CLASS_SCAN:


### PR DESCRIPTION
Previously gkeepd inconsistently printed messages to standard output on events. Now lines that are logged to gkeepd.log are also printed to standard output.