### PR TITLE
Adjust git usage due to new git behavior

### DIFF
--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -101,7 +101,8 @@ def get_git_branch(repo_path):
     return branch
 
 
-def git_push(repo_path, dest=None, branch=None, force=False, sudo=False):
+def git_push(repo_path, dest=None, branch=None, force=False, sudo=False,
+             user=None):
     """
     Push a repository to its upstream remote, or to a specific destination.
 
@@ -111,7 +112,8 @@ def git_push(repo_path, dest=None, branch=None, force=False, sudo=False):
     :param dest: optional destination to push to
     :param branch: optional branch, if dest is specified
     :param force: set to True to force a push (be careful!)
-    :param sudo: if true command is run as root
+    :param sudo: if true command is run as root or another user
+    :param user: if not none and sudo is True, the push is run as this user
     """
     cmd = ['git', 'push']
 
@@ -124,7 +126,7 @@ def git_push(repo_path, dest=None, branch=None, force=False, sudo=False):
 
         cmd += [dest, branch]
 
-    run_command_in_directory(repo_path, cmd, sudo=sudo)
+    run_command_in_directory(repo_path, cmd, sudo=sudo, user=user)
 
 
 def git_pull(repo_path, remote_url=None):
@@ -210,17 +212,21 @@ def git_checkout(repo_path, branch_or_commit):
     run_command_in_directory(repo_path, cmd)
 
 
-def git_head_hash(repo_path):
+def git_head_hash(repo_path, user=None):
     """
     Get the hash of the HEAD of a git repository.
 
     :param repo_path: path to the repository
+    :param user: username of the owner of the repository
     :return: commit hash of HEAD
     """
 
     cmd = ['git', 'rev-parse', 'HEAD']
 
-    return run_command_in_directory(repo_path, cmd).rstrip()
+    sudo = user is not None
+
+    return run_command_in_directory(repo_path, cmd, sudo=sudo,
+                                    user=user).rstrip()
 
 
 def git_head_hash_date(repo_path):
@@ -247,7 +253,7 @@ def git_head_hash_date(repo_path):
     return repo_hash, timestamp
 
 
-def git_hashes_and_times(repo_path):
+def git_hashes_and_times(repo_path, user=None):
     """
     Get the hashes and commit times of the commits to a git repository.
 
@@ -256,12 +262,15 @@ def git_hashes_and_times(repo_path):
     The hashes are strings.
 
     :param repo_path: path to the repository
+    :param user: the username of the repository owner
     :return: list containing (hash, time) tuples
     """
 
     cmd = ['git', 'log', '--format=%H %at']
 
-    output = run_command_in_directory(repo_path, cmd)
+    sudo = user is not None
+
+    output = run_command_in_directory(repo_path, cmd, sudo=sudo, user=user)
     lines = output.splitlines()
 
     hashes_and_times = []

--- a/git-keeper-core/gkeepcore/path_utils.py
+++ b/git-keeper-core/gkeepcore/path_utils.py
@@ -112,6 +112,7 @@ def user_log_path(gitkeeper_path: str, username: str):
     <user .gitkeeper directory>/<username>.log
 
     :param gitkeeper_path: the path to the user's .gitkeeper directory
+    :param username: username of the log's owner
     :return: the user's log path
     """
 
@@ -190,28 +191,29 @@ def parse_submission_repo_path(path) -> (str, str, str, str):
     return faculty_username, class_name, assignment_name
 
 
-def parse_faculty_assignment_path(path) -> (str, str):
+def parse_faculty_assignment_path(path) -> (str, str, str):
     """
-    Extract the class name and assignment name from a path to a faculty
-    assignment directory.
+    Extract the faculty username, class name, and assignment name from a path
+    to a faculty assignment directory.
 
     :param path: path to the assignment directory
-    :return: a tuple containing the class name and the assignment name, or
-             None if the path is malformed
+    :return: a tuple containing the faculty username, the class name,
+     and the assignment name, or None if the path is malformed
     """
 
     # we're parsing a path that ends with this:
-    # <class>/<assignment>
+    # <faculty username>/.gitkeeper/classes/<class>/<assignment>
 
     path_list = path_to_list(path)
 
-    if len(path_list) < 2:
+    if len(path_list) < 5:
         return None
 
-    # the information we want is in the last 2 elements of the list
+    # the class name and assignment name are the last 2 elements of the list
     class_name, assignment_name = path_list[-2:]
+    faculty_username = path_list[-5]
 
-    return class_name, assignment_name
+    return faculty_username, class_name, assignment_name
 
 
 def parse_faculty_class_path(path) -> str:

--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -22,7 +22,6 @@ from tempfile import TemporaryDirectory
 
 from gkeepcore.action_scripts import get_action_script_and_interpreter
 from gkeepcore.student import Student
-from gkeepcore.upload_directory import UploadDirectory
 from pkg_resources import resource_exists, resource_string, ResolutionError, \
     ExtractionError
 
@@ -94,10 +93,12 @@ class AssignmentDirectory:
         path_info = parse_faculty_assignment_path(path)
 
         if path_info is None:
+            self.faculty_username = None
             self.class_name = None
             self.assignment_name = None
         else:
-            self.class_name, self.assignment_name = path_info
+            self.faculty_username, self.class_name, self.assignment_name = \
+                path_info
 
         if check:
             self.check()

--- a/git-keeper-server/gkeepserver/event_handlers/trigger_handler.py
+++ b/git-keeper-server/gkeepserver/event_handlers/trigger_handler.py
@@ -110,7 +110,8 @@ class TriggerHandler(EventHandler):
                                              self._class_name,
                                              self._assignment_name, home_dir)
 
-            commit_hash = git_head_hash(submission_repo_path)
+            commit_hash = git_head_hash(submission_repo_path,
+                                        user=student.username)
 
             submission = Submission(student, submission_repo_path, commit_hash,
                                     assignment_dir, self._faculty_username,

--- a/git-keeper-server/gkeepserver/info_update_thread.py
+++ b/git-keeper-server/gkeepserver/info_update_thread.py
@@ -435,7 +435,8 @@ class InfoUpdateThread(Thread):
             return
 
         reports_repo_path = assignment_dir.reports_repo_path
-        reports_repo_hash = git_head_hash(assignment_dir.reports_repo_path)
+        reports_repo_hash = git_head_hash(assignment_dir.reports_repo_path,
+                                          user=faculty_username)
 
         reports_repo_info = {
             'path': reports_repo_path,
@@ -457,7 +458,8 @@ class InfoUpdateThread(Thread):
                                              assignment_name, student_home_dir)
 
             try:
-                hashes_and_times = git_hashes_and_times(assignment_repo_path)
+                hashes_and_times = git_hashes_and_times(assignment_repo_path,
+                                                        user=student.username)
             except GkeepException as e:
                 warning = ('Could not get hashes for {0}: {1}'
                            .format(assignment_repo_path, e))

--- a/git-keeper-server/gkeepserver/reports.py
+++ b/git-keeper-server/gkeepserver/reports.py
@@ -1,0 +1,57 @@
+# Copyright 2022 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import contextlib
+import os
+from tempfile import TemporaryDirectory
+from time import time
+
+from gkeepcore.git_commands import git_clone, git_push
+from gkeepcore.system_commands import sudo_chown, mv, rm
+from gkeepserver.assignments import AssignmentDirectory
+from gkeepserver.server_configuration import config
+
+
+@contextlib.contextmanager
+def reports_clone(assignment_dir: AssignmentDirectory):
+    """
+    Provides a context manager to use when making changes to a reports
+    repository. A clone of the repository is made in a temporary directory,
+    and the path to the clone is yielded to the caller. The caller is
+    responsible for adding and committing changes within this clone. Afterwords
+    the clone is moved into the assignment directory, ownership is changed to
+    be the faculty user, the changes in the clone are pushed to the bare
+    reports repo, and then the clone is deleted.
+
+    :param assignment_dir: AssignmentDirectory object associated with the
+     assignment directory that contains the reports repository
+    """
+
+    with TemporaryDirectory() as temp_path:
+        temp_reports_clone_path = os.path.join(temp_path, 'reports')
+        git_clone(assignment_dir.reports_repo_path, temp_path)
+
+        yield temp_reports_clone_path
+
+        reports_clone_path = os.path.join(assignment_dir.path,
+                                          'reports_clone_{}'.format(time()))
+        mv(temp_reports_clone_path, reports_clone_path, sudo=True)
+
+    sudo_chown(reports_clone_path, assignment_dir.faculty_username,
+               config.keeper_group, recursive=True)
+    git_push(reports_clone_path, sudo=True,
+             user=assignment_dir.faculty_username)
+    rm(reports_clone_path, recursive=True, sudo=True)


### PR DESCRIPTION
Due to a vulnerability, git no longer allows commands to be issued
when the user issuing the commands is not the same as the owner of
the repositories involved. This required changes to the way that
gkeepd pushes to reports repositories, and the way that it retrieves
hashes from repositories.