### PR TITLE
Enable gkeep test to trigger if solution is up-to-date

### DIFF
--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -101,6 +101,23 @@ def get_git_branch(repo_path):
     return branch
 
 
+def git_unstaged_changes_exist(repo_path):
+    """
+    Determine if a git repository has unstaged changes.
+
+    :param repo_path: path of the repository
+    :return: True if unstaged changes exist, False otherwise
+    """
+
+    cmd = ['git', '-C', repo_path, 'diff', '--exit-code']
+
+    try:
+        run_command(cmd)
+        return False
+    except CommandError:
+        return True
+
+
 def git_push(repo_path, dest=None, branch=None, force=False, sudo=False,
              user=None):
     """

--- a/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
@@ -92,6 +92,14 @@ class ServerCheckKeywords:
             raise GkeepRobotException('Submission test result email exists for {}, {}, {}'.format(username, course_name,
                                                                                     assignment_name))
 
+    def verify_submission_test_result_count(self, username, course_name, assignment_name, body_contains, count):
+        subject = '"[{}] {} submission test results"'.format(course_name, assignment_name)
+        result = control.run_vm_python_script('keeper', 'email_to_count.py',
+                                              username, subject, body_contains, count)
+        if result != 'True':
+            raise GkeepRobotException('Did not see {} submission test result emails for {}, {}, {}'
+                                      .format(count, username, course_name, assignment_name))
+
     def email_exists(self, to_user, subject_contains=None, body_contains=None):
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               to_user, subject_contains, body_contains)

--- a/tests/acceptance/gkeep_test.robot
+++ b/tests/acceptance/gkeep_test.robot
@@ -37,6 +37,13 @@ Test Produces Email to Faculty
     Gkeep Test Succeeds    faculty1    cs1    good_simple    good_simple/correct_solution
     Submission Test Results Email Exists    faculty1    cs1    good_simple    Done
 
+
+Two Tests Produce Two Emails to Faculty
+    Gkeep Test Succeeds    faculty1    cs1    good_simple    good_simple/correct_solution
+    Gkeep Test Succeeds    faculty1    cs1    good_simple    good_simple/correct_solution
+    Verify Submission Test Result Count    faculty1    cs1    good_simple    Done    2
+
+
 Test Fails on Bad Course Name
     [Tags]  error
     Gkeep Test Fails    faculty1    bad_course    good_simple    good_simple/correct_solution

--- a/tests/acceptance/vm_scripts/email_to_count.py
+++ b/tests/acceptance/vm_scripts/email_to_count.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from gkeeprobot.dectorators import polling
+import glob
+import sys
+
+
+@polling
+def check_email_count(to, expected_count, subject_contains=None, body_contains=None):
+    count = 0
+    for file in glob.glob('/email/{}_*.txt'.format(to)):
+        if check_email_contains(file, subject_contains=subject_contains, body_contains=body_contains):
+            count += 1
+
+    return count == expected_count
+
+def check_email_contains(filename, subject_contains=None, body_contains=None):
+    with open(filename) as f:
+        from_line = f.readline()
+        subject_line = f.readline()
+        body = f.read()
+
+        if subject_contains is not None and subject_contains not in subject_line:
+            return False
+
+        if body_contains is not None and body_contains not in body:
+            return False
+
+        return True
+
+
+print(check_email_count(sys.argv[1], int(sys.argv[4]), subject_contains=sys.argv[2], body_contains=sys.argv[3]))


### PR DESCRIPTION
Before this change, gkeep test would do nothing if the solution files
were the same as they were the last time gkeep test was run. Now gkeep
test switches to using the gkeep trigger functionality in that case to
trigger the tests to run again.