### PR TITLE
Use -C with git rather than changing directory

### DIFF
--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -18,8 +18,7 @@
 
 import os
 
-from gkeepcore.shell_command import run_command_in_directory, run_command, \
-    CommandError
+from gkeepcore.shell_command import run_command, CommandError
 
 
 def git_remote_add(repo_path, remote_name, url):
@@ -32,8 +31,9 @@ def git_remote_add(repo_path, remote_name, url):
     :param remote_name: name of the remote
     :param url: URL of the remote
     """
-    cmd = ['git', 'remote', 'add', remote_name, url]
-    run_command_in_directory(repo_path, cmd)
+
+    cmd = ['git', '-C', repo_path, 'remote', 'add', remote_name, url]
+    run_command(cmd)
 
 
 def git_init(repo_path):
@@ -45,8 +45,8 @@ def git_init(repo_path):
     :param repo_path: path to the directory in which to initialize the
      repository
     """
-    cmd = ['git', 'init']
-    run_command_in_directory(repo_path, cmd)
+    cmd = ['git', '-C', repo_path, 'init']
+    run_command(cmd)
 
 
 def git_init_bare(repo_path):
@@ -58,8 +58,8 @@ def git_init_bare(repo_path):
     :param repo_path: path to the directory in which to initialize the
      repository
     """
-    cmd = ['git', 'init', '--bare']
-    run_command_in_directory(repo_path, cmd)
+    cmd = ['git', '-C', repo_path, 'init', '--bare']
+    run_command(cmd)
 
 
 def git_add_all(repo_path):
@@ -70,8 +70,8 @@ def git_add_all(repo_path):
 
     :param repo_path: path to the repository
     """
-    cmd = ['git', 'add', '-A']
-    run_command_in_directory(repo_path, cmd)
+    cmd = ['git', '-C', repo_path, 'add', '-A']
+    run_command(cmd)
 
 
 def git_commit(repo_path, message):
@@ -83,8 +83,8 @@ def git_commit(repo_path, message):
     :param repo_path: path to the repository
     :param message: commit message
     """
-    cmd = ['git', 'commit', '-m', message]
-    run_command_in_directory(repo_path, cmd)
+    cmd = ['git', '-C', repo_path, 'commit', '-m', message]
+    run_command(cmd)
 
 
 def get_git_branch(repo_path):
@@ -95,8 +95,8 @@ def get_git_branch(repo_path):
     :return: name of the current branch
     """
 
-    cmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
-    branch = run_command_in_directory(repo_path, cmd).strip()
+    cmd = ['git', '-C', repo_path, 'rev-parse', '--abbrev-ref', 'HEAD']
+    branch = run_command(cmd).strip()
 
     return branch
 
@@ -115,7 +115,7 @@ def git_push(repo_path, dest=None, branch=None, force=False, sudo=False,
     :param sudo: if true command is run as root or another user
     :param user: if not none and sudo is True, the push is run as this user
     """
-    cmd = ['git', 'push']
+    cmd = ['git', '-C', repo_path, 'push']
 
     if force:
         cmd.append('-f')
@@ -126,7 +126,7 @@ def git_push(repo_path, dest=None, branch=None, force=False, sudo=False,
 
         cmd += [dest, branch]
 
-    run_command_in_directory(repo_path, cmd, sudo=sudo, user=user)
+    run_command(cmd, sudo=sudo, user=user)
 
 
 def git_pull(repo_path, remote_url=None):
@@ -137,12 +137,12 @@ def git_pull(repo_path, remote_url=None):
     :param remote_url: URL to pull from, None to pull from upstream remote
     """
 
-    cmd = ['git', 'pull']
+    cmd = ['git', '-C', repo_path, 'pull']
 
     if remote_url is not None:
         cmd.append(remote_url)
 
-    run_command_in_directory(repo_path, cmd)
+    run_command(cmd)
 
 
 def git_config(repo_path, config_options):
@@ -154,10 +154,10 @@ def git_config(repo_path, config_options):
       config
     """
 
-    cmd = ['git', 'config']
+    cmd = ['git', '-C', repo_path, 'config']
     cmd.extend(config_options)
 
-    run_command_in_directory(repo_path, cmd)
+    run_command(cmd)
 
 
 def is_non_bare_repo(repo_path):
@@ -182,9 +182,9 @@ def git_clone(source_repo_path, target_path):
     :return: None
     """
 
-    cmd = ['git', 'clone', source_repo_path]
+    cmd = ['git', '-C', target_path, 'clone', source_repo_path]
 
-    run_command_in_directory(target_path, cmd)
+    run_command(cmd)
 
 
 def git_clone_remote(remote_repo_url, local_repo_path):
@@ -207,9 +207,9 @@ def git_checkout(repo_path, branch_or_commit):
     :param branch_or_commit: name of the branch or the commit hash to checkout
     """
 
-    cmd = ['git', 'checkout', branch_or_commit]
+    cmd = ['git', '-C', repo_path, 'checkout', branch_or_commit]
 
-    run_command_in_directory(repo_path, cmd)
+    run_command(cmd)
 
 
 def git_head_hash(repo_path, user=None):
@@ -221,12 +221,11 @@ def git_head_hash(repo_path, user=None):
     :return: commit hash of HEAD
     """
 
-    cmd = ['git', 'rev-parse', 'HEAD']
+    cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
 
     sudo = user is not None
 
-    return run_command_in_directory(repo_path, cmd, sudo=sudo,
-                                    user=user).rstrip()
+    return run_command(cmd, sudo=sudo, user=user).rstrip()
 
 
 def git_head_hash_date(repo_path):
@@ -239,9 +238,9 @@ def git_head_hash_date(repo_path):
     :return: tuple containing the hash and the timestamp
     """
 
-    cmd = ['git', 'log', '-1', '--format=%H %at']
+    cmd = ['git', '-C', repo_path, 'log', '-1', '--format=%H %at']
 
-    output = run_command_in_directory(repo_path, cmd)
+    output = run_command(cmd)
     split_output = output.split()
 
     if len(split_output) != 2:
@@ -266,11 +265,11 @@ def git_hashes_and_times(repo_path, user=None):
     :return: list containing (hash, time) tuples
     """
 
-    cmd = ['git', 'log', '--format=%H %at']
+    cmd = ['git', '-C', repo_path, 'log', '--format=%H %at']
 
     sudo = user is not None
 
-    output = run_command_in_directory(repo_path, cmd, sudo=sudo, user=user)
+    output = run_command(cmd, sudo=sudo, user=user)
     lines = output.splitlines()
 
     hashes_and_times = []

--- a/git-keeper-core/gkeepcore/shell_command.py
+++ b/git-keeper-core/gkeepcore/shell_command.py
@@ -88,6 +88,9 @@ class ChangeDirectoryContext:
     For use as a context manager to change into a directory and change out
     again.
 
+    THE WORKING DIRECTORY IS CHANGED AT THE PROCESS LEVEL, AND AS SUCH IT IS
+    NOT SAFE FOR MORE THAN ONE THREAD TO USE THIS CONTEXT MANAGER.
+
     Example:
 
         with ChangeDirectoryContext('path/to/dir'):
@@ -111,6 +114,9 @@ def run_command_in_directory(path, command, sudo=False, user=None,
                              stderr=STDOUT):
     """
     Change into a new working directory, run a command, and change back.
+
+    THE WORKING DIRECTORY IS CHANGED AT THE PROCESS LEVEL, AND AS SUCH IT IS
+    NOT SAFE FOR MORE THAN ONE THREAD TO USE THIS FUNCTION.
 
     Raises CommandError if the command could not be called or has a non-zero
     exit code.


### PR DESCRIPTION
Previously before calling git commands, the working directory was
changed with os.chdir(). Multiple threads may execute git commands
simultaneously and os.chdir() changes the working directory at the
process level, so there were a number of race conditions due to
running git commands this way.

Now git commands use the -C option to specify the git directory
without needing to change the working directory.