### PR TITLE
Disallow configuring users and groups

### DIFF
--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -156,11 +156,6 @@ The `[gkeepd]` section is optional. Below are the allowed parameters and their
 defaults:
 
 ```
-keeper_user: keeper
-keeper_group: keeper
-tester_user: tester
-faculty_group: faculty
-student_group: student
 tests_timeout: 300
 tests_memory_limit: 1024
 ```
@@ -194,11 +189,6 @@ admin_first_name:
 admin_last_name: 
 
 #[gkeepd]
-#keeper_user: keeper
-#keeper_group: keeper
-#tester_user: tester
-#faculty_group: faculty
-#student_group: student
 #tests_timeout: 300
 #tests_memory_limit: 1024
 ```

--- a/git-keeper-server/gkeepserver/server_configuration.py
+++ b/git-keeper-server/gkeepserver/server_configuration.py
@@ -18,7 +18,7 @@
 This module allows the parsing of and provides access to the the server
 configuration file.
 
-The default configuration file localtion is ~/server.cfg. This can be
+The default configuration file location is ~/server.cfg. This can be
 customized by passing a path to parser().
 
 The configuration file must be in the INI format:
@@ -341,11 +341,6 @@ class ServerConfiguration:
             'test_thread_count',
             'tests_timeout',
             'tests_memory_limit',
-            'keeper_user',
-            'keeper_group',
-            'tester_user',
-            'faculty_group',
-            'student_group'
         ]
 
         for name in optional_options:


### PR DESCRIPTION
Allowing configuration of the usernames and groups for keeper and tester
and the groups for faculty and students would lead to problems if they
are changed after running gkeepd for the first time.