### PR TITLE
Add gkeepd --check command to check server.cfg

### DIFF
--- a/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
@@ -41,12 +41,29 @@ class ServerCheckKeywords:
         except ExitCodeException:
             pass
 
+    def gkeepd_check_succeeds(self):
+        control.run('keeper', 'gkeepd --check')
+
+    def gkeepd_check_fails(self):
+        try:
+            control.run('keeper', 'gkeepd --check')
+            raise GkeepRobotException('gkeepd --check should return non-zero')
+        except ExitCodeException:
+            pass
+
     def new_account_email_exists(self, username):
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               username, '"New git-keeper account"',
                                               'Password')
         if result != 'True':
             raise GkeepRobotException('No new account email for {}'.format(username))
+
+    def gkeepd_check_email_exists(self, username):
+        result = control.run_vm_python_script('keeper', 'email_to.py',
+                                              username, '"git-keeper test email"',
+                                              'This is a test email')
+        if result != 'True':
+            raise GkeepRobotException('No gkeepd check email for {}'.format(username))
 
     def password_reset_email_exists(self, username):
         result = control.run_vm_python_script('keeper', 'email_to.py',

--- a/git-keeper-server/gkeepserver/check_config.py
+++ b/git-keeper-server/gkeepserver/check_config.py
@@ -1,0 +1,60 @@
+# Copyright 2022 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from gkeepcore.gkeep_exception import GkeepException
+from gkeepserver.server_configuration import config, ServerConfigurationError
+from gkeepserver.server_email import Email
+
+
+def check_config():
+    """
+    Check the gkeepd server configuration file for syntax errors, and attempt
+    to send an email to the admin user defined in the configuration file.
+
+    If there are any errors, a GkeepException is raised.
+    """
+
+    try:
+        config.parse()
+    except ServerConfigurationError as e:
+        error = ('There was an error parsing the gkeepd configuration file:\n{}'
+                 .format(e))
+        raise GkeepException(error)
+
+    print('{} was parsed without errors'.format(config.config_path))
+
+    test_email_subject = 'git-keeper test email'
+    test_email_body = ('This is a test email to check that the git-keeper '
+                       'server with the configured hostname {} is able to '
+                       'send email. This message was sent to {}, which is the '
+                       'configured admin email address. If this '
+                       'message reaches its intended destination, then the '
+                       'git-keeper server is able to send email.'
+                       .format(config.hostname, config.admin_email))
+
+    print('Attempting to send an email to {} with the subject "{}"'
+          .format(config.admin_email, test_email_subject))
+
+    try:
+        email = Email(config.admin_email, test_email_subject, test_email_body)
+        email.send()
+    except Exception as e:
+        error = 'There was an error in sending the email:\n{}\n'.format(e)
+        error += 'Please check your email configuration'
+        raise GkeepException(error)
+
+    print('The test email was sent without errors.\n'
+          'Please confirm that the email was received.')

--- a/git-keeper-server/gkeepserver/gkeepd.py
+++ b/git-keeper-server/gkeepserver/gkeepd.py
@@ -35,6 +35,7 @@ from signal import signal, SIGINT, SIGTERM
 
 from gkeepcore.gkeep_exception import GkeepException
 from gkeepcore.version import __version__ as core_version
+from gkeepserver.check_config import check_config
 from gkeepserver.check_system import check_system
 from gkeepserver.database import db
 from gkeepserver.email_sender_thread import email_sender
@@ -80,12 +81,22 @@ def main():
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('-v', '--version', action='store_true',
                         help='Print gkeepd version')
+    parser.add_argument('-c', '--check', action='store_true',
+                        help='Validate config and send test email to admins')
 
     args = parser.parse_args()
 
     if args.version:
         print('gkeepd version {}'.format(server_version))
         sys.exit(0)
+
+    if args.check:
+        try:
+            check_config()
+            sys.exit(0)
+        except Exception as e:
+            print(e)
+            sys.exit(1)
 
     # setup signal handling
     global shutdown_flag

--- a/git-keeper-server/gkeepserver/server_configuration.py
+++ b/git-keeper-server/gkeepserver/server_configuration.py
@@ -116,7 +116,7 @@ class ServerConfiguration:
         self.home_dir = os.path.expanduser('~')
         self.username = getuser()
 
-        self._config_path = None
+        self.config_path = None
 
         self._parsed = False
 
@@ -136,12 +136,12 @@ class ServerConfiguration:
 
         if config_path is None:
             config_filename = 'server.cfg'
-            self._config_path = os.path.join(self.home_dir, config_filename)
+            self.config_path = os.path.join(self.home_dir, config_filename)
         else:
-            self._config_path = config_path
+            self.config_path = config_path
 
-        if not os.path.isfile(self._config_path):
-            error = '{0} does not exist'.format(self._config_path)
+        if not os.path.isfile(self.config_path):
+            error = '{0} does not exist'.format(self.config_path)
             raise ServerConfigurationError(error)
 
         self._initialize_default_attributes()
@@ -218,9 +218,9 @@ class ServerConfiguration:
         self._parser = configparser.ConfigParser()
 
         try:
-            self._parser.read(self._config_path)
+            self._parser.read(self.config_path)
         except configparser.ParsingError as e:
-            error = 'Error reading {0}: {1}'.format(self._config_path,
+            error = 'Error reading {0}: {1}'.format(self.config_path,
                                                     e.message)
             raise ServerConfigurationError(error)
 
@@ -229,7 +229,7 @@ class ServerConfiguration:
 
         if section not in self._parser.sections():
             error = ('section {0} is not present in {1}'
-                     .format(section, self._config_path))
+                     .format(section, self.config_path))
             raise ServerConfigurationError(error)
 
     def _set_email_options(self):

--- a/tests/acceptance/gkeepd_check.robot
+++ b/tests/acceptance/gkeepd_check.robot
@@ -1,0 +1,47 @@
+# Copyright 2022 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+*** Settings ***
+Resource    resources/setup.robot
+Test Setup    Reset Server
+Force Tags    gkeepd_check
+
+*** Test Cases ***
+
+Check Valid Setup
+    [Tags]    happy_path
+    Add File To Server    keeper    files/valid_server.cfg    server.cfg
+    Gkeepd Check Succeeds
+    Gkeepd Check Email Exists    admin_prof
+    Gkeepd Is Not Running
+    User Does Not Exist On Server    admin_prof
+
+Check Valid Setup While Gkeepd Is Running
+    [Tags]    happy_path
+    Add File To Server    keeper    files/valid_server.cfg    server.cfg
+    Start gkeepd
+    Gkeepd Check Succeeds
+    Gkeepd Check Email Exists    admin_prof
+    Gkeepd Is Running
+
+Check Missing Server cfg
+    [Tags]    error
+    Gkeepd Check Fails
+
+Check Malformed Server cfg
+    [Tags]    error
+    Add File To Server    keeper    files/malformed_server.cfg    server.cfg
+    Gkeepd Check Fails


### PR DESCRIPTION
The new `gkeepd --check` command parses server.cfg to check for syntax errors and sends a test
email to the admin user to confirm that email sending has been configured correctly.