### PR TITLE
Fix gkeep modify behavior when changing names

### DIFF
--- a/git-keeper-client/gkeepclient/server_actions.py
+++ b/git-keeper-client/gkeepclient/server_actions.py
@@ -199,7 +199,7 @@ def class_modify(class_name: str, csv_file_path: str, yes: bool):
             old_last = existing_students_by_email[email_address]['last']
             print('{}, {} -> {}, {}'.format(old_last, old_first, last_name,
                                             first_name))
-            update_name_rows.append((first_name, last_name, email_address))
+            update_name_rows.append((last_name, first_name, email_address))
 
     if not changes_exist:
         raise GkeepException('There are no changes to be made')

--- a/git-keeper-server/gkeepserver/database.py
+++ b/git-keeper-server/gkeepserver/database.py
@@ -243,7 +243,9 @@ class Database:
             raise DatabaseException(error)
 
         student_id = self._user_id_from_username(student.username)
-        class_student = DBClassStudent.get(DBClassStudent.user_id == student_id)
+        class_id = self._get_class_id(class_name, faculty_username)
+        class_student = DBClassStudent.get(DBClassStudent.user_id == student_id,
+                                           DBClassStudent.class_id == class_id)
         class_student.first_name = student.first_name
         class_student.last_name = student.last_name
         class_student.save()

--- a/tests/acceptance/files/cs1_change_name.csv
+++ b/tests/acceptance/files/cs1_change_name.csv
@@ -1,0 +1,2 @@
+NewLast,NewFirst,student1@gitkeeper.edu
+Last,First,student2@gitkeeper.edu

--- a/tests/acceptance/gkeep_modify.robot
+++ b/tests/acceptance/gkeep_modify.robot
@@ -59,3 +59,9 @@ Remove Then Add Student
     Add To Class CSV    faculty=faculty1    class_name=cs1    username=student2
     Gkeep Modify Succeeds    faculty=faculty1    class_name=cs1
     Class Contains Student    faculty1    cs1    student2
+
+Change Student Name
+    [Tags]    happy_path
+    Add File To Client    faculty1    files/cs1_change_name.csv    cs1.csv
+    Gkeep Modify Succeeds    faculty=faculty1    class_name=cs1
+    Gkeep Query JSON Produces Results    faculty1   students   {"cs1":[{"first_name":"NewFirst","last_name":"NewLast","username":"student1","email_address":"student1@gitkeeper.edu"},{"first_name":"First","last_name":"Last","username":"student2","email_address":"student2@gitkeeper.edu"}]}

--- a/tests/acceptance/resources/setup.robot
+++ b/tests/acceptance/resources/setup.robot
@@ -24,12 +24,14 @@ Library    gkeeprobot.keywords.ClientCheckKeywords
 
 Add Faculty and Configure Accounts on Client
     [Arguments]    @{faculty_names}
-    :FOR    ${username}    IN    @{faculty_names}
-    \        Gkeep Add Faculty Succeeds    admin_prof    ${username}
-    \        Wait For Email    to_user=${username}    subject_contains="New git-keeper account"    body_contains=Password
+    FOR    ${username}    IN    @{faculty_names}
+            Gkeep Add Faculty Succeeds    admin_prof    ${username}
+            Wait For Email    to_user=${username}    subject_contains="New git-keeper account"    body_contains=Password
+    END
     Create Accounts On Client  @{faculty_names}
-    :FOR    ${username}    IN    @{faculty_names}
-    \            Create Git Config    ${username}
+    FOR    ${username}    IN    @{faculty_names}
+                Create Git Config    ${username}
+    END
 
 Launch Gkeepd And Configure Admin Account on Client
     Reset Server
@@ -42,14 +44,16 @@ Launch Gkeepd And Configure Admin Account on Client
 
 Establish Course
     [Arguments]    ${faculty}    ${class}    @{students}
-    :FOR     ${student}    IN    @{students}
-    \    Add To Class CSV   faculty=${faculty}    class_name=${class}    username=${student}
+    FOR     ${student}    IN    @{students}
+        Add To Class CSV   faculty=${faculty}    class_name=${class}    username=${student}
+    END
     Gkeep Add Succeeds    faculty=${faculty}   class_name=${class}
 
 
 Create Accounts On Client
     [Arguments]    @{usernames}
-    :FOR    ${username}    IN    @{usernames}
-    \       Create Account    ${username}
-    \       Establish SSH Keys    ${username}
-    \       Create Gkeep Config File    ${username}
+    FOR    ${username}    IN    @{usernames}
+           Create Account    ${username}
+           Establish SSH Keys    ${username}
+           Create Gkeep Config File    ${username}
+    END

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -421,13 +421,25 @@ def test_get_class_assignments(db):
     db.set_published('class', 'assgn3', 'faculty')
     db.disable_assignment('class', 'assgn3', 'faculty')
 
-    assignments = db.get_class_assignments('class', 'faculty')
+    all_assignments = db.get_class_assignments('class', 'faculty',
+                                               include_disabled=True)
 
-    assert len(assignments) == 3
+    assert len(all_assignments) == 3
 
     assgn1 = Assignment('assgn1', 'class', 'faculty', False, False)
     assgn2 = Assignment('assgn2', 'class', 'faculty', True, False)
     assgn3 = Assignment('assgn3', 'class', 'faculty', True, True)
 
     for assignment in (assgn1, assgn2, assgn3):
-        assert assignment in assignments
+        assert assignment in all_assignments
+
+    enabled_assignments = db.get_class_assignments('class', 'faculty')
+
+    assert len(enabled_assignments) == 2
+
+    assgn1 = Assignment('assgn1', 'class', 'faculty', False, False)
+    assgn2 = Assignment('assgn2', 'class', 'faculty', True, False)
+
+    for assignment in (assgn1, assgn2):
+        assert assignment in enabled_assignments
+


### PR DESCRIPTION
This fixes 2 bugs regarding changing student names using gkeep modify. Previously a student's first and last name would be flipped with each other when changing names. There was also the possibility that a student's name would change for the wrong class roster.