### PR TITLE
Move event handling to a new thread

### DIFF
--- a/git-keeper-server/gkeepserver/event_handler_assigner.py
+++ b/git-keeper-server/gkeepserver/event_handler_assigner.py
@@ -98,20 +98,21 @@ class EventHandlerAssignerThread(Thread):
     def _examine_all_new_events(self):
         # Examine all new log events that are in the queue
 
-        try:
-            while True:
+        empty = False
+        while not empty:
+            try:
                 # block for a short time so we don't hog the CPU when the
                 # queue is empty
                 log_path, log_event = \
                     self._new_log_event_queue.get(block=True, timeout=0.1)
 
                 self._examine_new_event(log_path, log_event)
-        except Empty:
-            # get() throws an Empty exception when the queue is empty
-            pass
-        except Exception as e:
-            error = 'Unexpected error in log event assigner: {0}'.format(e)
-            gkeepd_logger.log_error(error)
+            except Empty:
+                # get() throws an Empty exception when the queue is empty
+                empty = True
+            except Exception as e:
+                error = 'Unexpected error in log event assigner: {0}'.format(e)
+                gkeepd_logger.log_error(error)
 
     def _examine_new_event(self, log_path: str, log_event: LogEvent):
         # Examine a single log event.

--- a/git-keeper-server/gkeepserver/event_handler_thread.py
+++ b/git-keeper-server/gkeepserver/event_handler_thread.py
@@ -1,0 +1,97 @@
+# Copyright 2022 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Provides a thread which runs event handlers.
+"""
+
+import traceback
+from queue import Queue, Empty
+from threading import Thread
+
+from gkeepcore.gkeep_exception import GkeepException
+
+
+class EventHandlerThread(Thread):
+    """
+    Thread class for running event handlers. Event handlers are passed to the
+    thread through the queue given to the initializer. Call the inherited
+    start() method to start the thread, and shut down the thread by calling
+    shutdown(). All items in the queue will be processed before fully shutting
+    down.
+    """
+    def __init__(self, event_handler_queue: Queue, logger):
+        """
+        Initialize the thread.
+
+        :param event_handler_queue: queue through which event handlers are
+         passed
+        :param logger: system logger
+        """
+        Thread.__init__(self)
+
+        self._event_handler_queue = event_handler_queue
+        self._logger = logger
+        self._shutdown_flag = False
+
+    def shutdown(self):
+        """
+        Shut down the thread.
+
+        The run loop will not exit until all events have been handled.
+
+        This thread blocks until the thread has died.
+        """
+
+        self._shutdown_flag = True
+        self.join()
+
+    def run(self):
+        """
+        Continually handle events as they arrive in the queue.
+
+        This method should not be called directly. Call the start() method
+        instead.
+        """
+        while not self._shutdown_flag:
+            self._handle_all_new_events()
+
+    def _handle_all_new_events(self):
+        # Handles all events in the queue until the queue is empty
+        empty = False
+        while not empty:
+            try:
+                handler = self._event_handler_queue.get(block=True,
+                                                        timeout=0.1)
+
+                self._logger.log_debug('New task: ' + str(handler))
+
+                handler.handle()
+            except Empty:
+                empty = True
+            except (GkeepException, Exception) as e:
+                # A handler's handle() method should catch all exceptions. If
+                # we get here there is likely an issue with the handler.
+                error = ('**ERROR: UNEXPECTED EXCEPTION**\n'
+                         'This is likely due to a bug.\n'
+                         'Please report this to the git-keeper developers '
+                         'along with the following stack trace:\n{0}'
+                         .format(traceback.format_exc()))
+                print(error)
+                log_error = ('Unexpected exception. Please report this bug '
+                             'along with the stack trace from gkeepd\'s '
+                             'standard output if possible. '
+                             '{0}: {1}'.format(type(e), e))
+                self._logger.log_error(log_error)

--- a/git-keeper-server/gkeepserver/log_polling.py
+++ b/git-keeper-server/gkeepserver/log_polling.py
@@ -263,22 +263,23 @@ class LogPollingThread(Thread):
                 self._stop_watching_log_file(reader)
 
         # consume all new log files until the queue is empty
-        try:
-            while True:
+        empty = False
+        while not empty:
+            try:
                 new_file_path = self._add_log_queue.get(block=False)
                 if isinstance(new_file_path, str):
                     self._start_watching_log_file(new_file_path)
                 else:
                     self._logger.log_warning('Log poller: {0} is not a string'
                                              .format(new_file_path))
-        except Empty:
-            pass
+            except Empty:
+                empty = True
 
         # each file should be polled on average once per polling_interval
         next_poll_time = self._last_poll_time + self._polling_interval
         sleep_time = next_poll_time - time()
 
-        if sleep_time > 0:
+        if sleep_time > 0 and not self._shutdown_flag:
             sleep(sleep_time)
 
 


### PR DESCRIPTION
Previously when gkeepd was shut down, some log events could be lost if
they were still in the event handler queue, because the loop that
processed items in the queue immediately exited on shutdown. How the
handling of these events is moved to its own thread which is shut down
in a similar manner to the other threads. All events will be handled
before gkeepd shuts down.