### PR TITLE
Fix gkeep modify test

### DIFF
--- a/tests/acceptance/files/cs1_change_name.csv
+++ b/tests/acceptance/files/cs1_change_name.csv
@@ -1,2 +1,2 @@
-NewLast,NewFirst,student1@gitkeeper.edu
-Last,First,student2@gitkeeper.edu
+NewLast,NewFirst,student1@school.edu
+Last,First,student2@school.edu

--- a/tests/acceptance/gkeep_modify.robot
+++ b/tests/acceptance/gkeep_modify.robot
@@ -64,4 +64,4 @@ Change Student Name
     [Tags]    happy_path
     Add File To Client    faculty1    files/cs1_change_name.csv    cs1.csv
     Gkeep Modify Succeeds    faculty=faculty1    class_name=cs1
-    Gkeep Query JSON Produces Results    faculty1   students   {"cs1":[{"first_name":"NewFirst","last_name":"NewLast","username":"student1","email_address":"student1@gitkeeper.edu"},{"first_name":"First","last_name":"Last","username":"student2","email_address":"student2@gitkeeper.edu"}]}
+    Gkeep Query JSON Produces Results    faculty1   students   {"cs1":[{"first_name":"NewFirst","last_name":"NewLast","username":"student1","email_address":"student1@school.edu"},{"first_name":"First","last_name":"Last","username":"student2","email_address":"student2@school.edu"}]}


### PR DESCRIPTION
Student email addresses in two files had the domain gitkeeper.edu instead of school.edu,
causing one gkeep modify test to fail.