### PR TITLE
Fix version match checking

### DIFF
--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -434,6 +434,19 @@ def run_query(query_type: str, number_of_days: int, output_json: bool):
         list_recent(number_of_days, output_json)
 
 
+def verify_core_version_match():
+    """
+    Exits with a non-zero exit code if the gkeepclient version does not match
+    the gkeepcore version.
+    """
+
+    if client_version != core_version:
+        error = 'git-keeper-client and git-keeper-core versions must match.\n'
+        error += 'client version: {}\n'.format(client_version)
+        error += 'core version: {}'.format(core_version)
+        sys.exit(error)
+
+
 def main():
     """
     gkeep entry point.
@@ -441,6 +454,8 @@ def main():
     Setup the command line argument parser, parse the arguments, and call the
     appropriate function.
     """
+
+    verify_core_version_match()
 
     # Initialize the parser object that will interpret the passed in
     # command line arguments
@@ -536,10 +551,4 @@ def take_action(parsed_args):
 
 
 if __name__ == '__main__':
-    if core_version != client_version:
-        error = 'git-keeper-client and git-keeper-core versions must match.\n'
-        error += 'client version: {}\n'.format(client_version)
-        error += 'core version: {}'.format(core_version)
-        sys.exit(error)
-
     main()

--- a/git-keeper-server/gkeepserver/gkeepd.py
+++ b/git-keeper-server/gkeepserver/gkeepd.py
@@ -69,6 +69,19 @@ def signal_handler(signum, frame):
     shutdown_flag = True
 
 
+def verify_core_version_match():
+    """
+    Exits with a non-zero exit code if the gkeepserver version does not match
+    the gkeepcore version.
+    """
+
+    if server_version != core_version:
+        error = 'git-keeper-server and git-keeper-core versions must match.\n'
+        error += 'server version: {}\n'.format(server_version)
+        error += 'core version: {}'.format(core_version)
+        sys.exit(error)
+
+
 def main():
     """
     Entry point of the gkeepd process.
@@ -76,6 +89,8 @@ def main():
     If gkeepd is run with the --version or -v flags, it will print the current
     version and exit.
     """
+
+    verify_core_version_match()
 
     description = ('gkeepd, the git-keeper server, version {}'
                    .format(server_version))
@@ -204,10 +219,4 @@ def main():
 
 
 if __name__ == '__main__':
-    if server_version != core_version:
-        error = 'git-keeper-server and git-keeper-core versions must match.\n'
-        error += 'server version: {}\n'.format(server_version)
-        error += 'core version: {}'.format(core_version)
-        sys.exit(error)
-
     main()


### PR DESCRIPTION
Checking for version matches with gkeepcore was checked within
if __name__ == '__main__' blocks instead of in main() in both
gkeep.py and gkeepd.py. Since the console scripts use main() as
the entry point, the checks were never performed.