### PR TITLE
Do not require test_env.yaml on the server

### DIFF
--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -132,11 +132,6 @@ class AssignmentDirectory:
         if self.action_script is None:
             raise AssignmentDirectoryError('action script')
 
-        # ensure there is a test_env.yaml.  It is optional on the
-        # client, but a default version is made on upload/update
-        if not os.path.isfile(self.test_env_path):
-            raise AssignmentDirectoryError('test_env.yaml')
-
 
 def get_assignment_dir(faculty_username: str, class_name: str,
                        assignment_name: str) -> AssignmentDirectory:


### PR DESCRIPTION
Checking to ensure that test_env.yaml exists in every assignment
directory on the server breaks compatibility with version 0.3.1.
This change removes that check.