### PR TITLE
Add sqlite3 to gkserver

### DIFF
--- a/tests/acceptance/gkserver_base/Vagrantfile
+++ b/tests/acceptance/gkserver_base/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
         mkdir -p /etc/apt/keyrings
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        apt-get update && apt-get install -y python3-pip git firejail
+        apt-get update && apt-get install -y python3-pip git sqlite3 firejail
         apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
         apt-get clean
         usermod -aG docker keeper


### PR DESCRIPTION
Even though the sqlite3 command line tool is not a dependency for
git-keeper-server, it is useful for it to be installed on gkserver for
diagnostic purposes.