### PR TITLE
Change email matching and username validation

### DIFF
--- a/git-keeper-core/gkeepcore/student.py
+++ b/git-keeper-core/gkeepcore/student.py
@@ -81,8 +81,6 @@ class Student:
                      .format(email_address))
             raise StudentError(error)
 
-        validate_username(username)
-
         return cls(last_name, first_name, username, email_address)
 
     def __repr__(self) -> str:

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -183,25 +183,29 @@ class ClientCheckKeywords:
                     .format(last_name, first_name, username, class_name))
             raise GkeepRobotException(error)
 
-    def gkeep_add_faculty_succeeds(self, admin, new_faculty):
+    def gkeep_add_faculty_succeeds(self, admin, new_faculty,
+                                   email_domain='school.edu'):
         last_name = 'Professor'
         first_name = 'Doctor'
-        email_address = '{}@school.edu'.format(new_faculty)
+        email_address = '{}@{}'.format(new_faculty, email_domain)
 
         client_control.run(admin, 'gkeep add_faculty {} {} {}'
                                    .format(last_name, first_name,
                                            email_address))
 
-    def gkeep_add_faculty_fails(self, admin, new_faculty):
+    def gkeep_add_faculty_fails(self, admin, new_faculty,
+                                email_domain='school.edu'):
         last_name = 'Professor'
         first_name = 'Doctor'
-        email_address = '{}@school.edu'.format(new_faculty)
+        email_address = '{}@{}'.format(new_faculty, email_domain)
+
+        gkeep_command = ('gkeep add_faculty {} {} {}'
+                         .format(last_name, first_name, email_address))
 
         try:
-            client_control.run(admin, 'gkeep add_faculty {} {} {}'
-                                       .format(last_name, first_name,
-                                               email_address))
-            error = 'gkeep add_faculty should have non-zero return'
+            client_control.run(admin, gkeep_command)
+            error = ('Command "{}" should have non-zero return'
+                     .format(gkeep_command))
             raise GkeepRobotException(error)
         except ExitCodeException:
             pass

--- a/git-keeper-server/gkeepserver/database.py
+++ b/git-keeper-server/gkeepserver/database.py
@@ -150,12 +150,14 @@ class Database:
     def email_exists(self, email_address):
         """
         Determines whether or not a user with the given email address exists
-        in the database.
+        in the database. Matching is case-insensitive.
 
         :param email_address: the email address to check
         :return: True if the email address exists, False if not
         """
-        query = DBUser.select().where(DBUser.email_address == email_address)
+
+        lower_email = pw.fn.LOWER(DBUser.email_address)
+        query = DBUser.select().where(lower_email == email_address.lower())
         return query.exists()
 
     def get_username_from_email(self, email_address):
@@ -168,7 +170,8 @@ class Database:
         :return: username of the user
         """
         try:
-            return DBUser.get(DBUser.email_address == email_address).username
+            lower_email = pw.fn.LOWER(DBUser.email_address)
+            return DBUser.get(lower_email == email_address.lower()).username
         except DBUser.DoesNotExist:
             error = 'No user with email address {}'.format(email_address)
             raise DatabaseException(error)
@@ -315,12 +318,13 @@ class Database:
         """
 
         try:
+            lower_email = pw.fn.LOWER(DBUser.email_address)
             user = (DBUser
                     .select(DBUser.username, DBUser.email_address,
                             DBFacultyUser.first_name, DBFacultyUser.last_name,
                             DBFacultyUser.admin)
                     .join(DBFacultyUser)
-                    .where(DBUser.email_address == email_address)).get()
+                    .where(lower_email == email_address.lower())).get()
             return Faculty(user.dbfacultyuser.last_name,
                            user.dbfacultyuser.first_name,
                            user.username, user.email_address,
@@ -1072,8 +1076,9 @@ class Database:
 
     def _student_id_from_email(self, email_address):
         try:
+            lower_email = pw.fn.LOWER(DBUser.email_address)
             student = DBUser.select().join(DBStudentUser).where(
-                (DBUser.email_address == email_address)
+                (lower_email == email_address.lower())
             ).get()
             return student.id
         except DBUser.DoesNotExist:

--- a/tests/acceptance/files/invalid_username.csv
+++ b/tests/acceptance/files/invalid_username.csv
@@ -1,1 +1,0 @@
-Last,First,é@school.edu

--- a/tests/acceptance/files/non_ascii_characters.csv
+++ b/tests/acceptance/files/non_ascii_characters.csv
@@ -1,0 +1,1 @@
+Last,First,füñńÿ@school.edu

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -71,10 +71,11 @@ Missing CSV
     [Tags]    error
     Gkeep Add Fails    faculty=faculty1    class_name=cs1
 
-Invalid Username
-    [Tags]    error
-    Add File To Client    faculty1    files/invalid_username.csv   invalid_username.csv
-    Gkeep add Fails    faculty=faculty1    class_name=invalid_username
+Non ASCII Characters
+    [Tags]    happy_path
+    Add File To Client    faculty1    files/non_ascii_characters.csv   non_ascii_characters.csv
+    Gkeep Add Succeeds    faculty=faculty1    class_name=non_ascii_characters
+    User Exists On Server    funny
 
 Existing Student
     [Tags]    error
@@ -133,5 +134,25 @@ Empty CSV
 
 No CSV
     [Tags]  happy_path
-    Make Empty File    faculty1    cs1.csv
     Gkeep Add No CSV Succeeds    faculty=faculty1    class_name=cs1
+
+Uppercase Email
+    [Tags]    happy_path
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=STUDENT1    email_domain=SCHOOL.EDU
+    Gkeep Add Succeeds    faculty=faculty1    class_name=cs1
+    Class Contains Student    faculty1    cs1    student1
+    User Exists On Server    student1
+
+Different Case Email Username
+    [Tags]    error
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=student1
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=STUDENT1
+    Gkeep Add Fails    faculty=faculty1    class_name=cs1
+    Gkeepd Is Running
+
+Different Case Email Domain
+    [Tags]    error
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=student1
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=student1    email_domain='SCHOOL.EDU'
+    Gkeep Add Fails    faculty=faculty1    class_name=cs1
+    Gkeepd Is Running

--- a/tests/acceptance/gkeep_add_faculty.robot
+++ b/tests/acceptance/gkeep_add_faculty.robot
@@ -47,6 +47,18 @@ Add Faculty As Non Admin
     Gkeep Add Faculty Fails    faculty1    prof3
     Gkeepd Is Running
 
+Different Case Email
+    [Tags]    error
+    Gkeep Add Faculty Succeeds    admin_prof    faculty1
+    Gkeep Add Faculty Fails    admin_prof    FaCuLtY1
+    Gkeep Add Faculty Fails    admin_prof    faculty1    email_domain='ScHoOl.EdU'
+
+Uppercase Email
+    [Tags]    happy_path
+    Gkeep Add Faculty Succeeds    admin_prof    FACULTY1    email_domain='SCHOOL.EDU'
+    New Account Email Exists    FACULTY1
+    User Exists On Server    faculty1
+
 Admin Promote And Demote
     [Tags]    happy_path
     Gkeep Add Faculty Succeeds    admin_prof    faculty1

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -294,6 +294,39 @@ def test_change_student_name(db):
     assert unchanged_student.last_name == 'one'
 
 
+def test_email_case(db):
+    student_all_lower = Student('last', 'first', 'username', 'username@school.edu')
+    student_upper_username = Student('last', 'first', 'USERNAME', 'USERNAME@school.edu')
+
+    db.insert_student(student_all_lower)
+
+    assert db.email_exists('username@school.edu')
+    assert db.email_exists('USERNAME@school.edu')
+
+    with pytest.raises(DatabaseException):
+        db.insert_student(student_upper_username)
+
+    assert db.get_username_from_email('UsErNaMe@school.edu') == 'username'
+
+    assert db._student_id_from_email('username@school.edu') == \
+        db._student_id_from_email('UsErNaMe@school.edu')
+
+    faculty_all_lower = Faculty('last', 'first', 'fuser', 'fuser@school.edu',
+                                False)
+    faculty_upper_username = Faculty('last', 'first', 'FUSER',
+                                     'FUSER@school.edu', False)
+
+    db.insert_faculty(faculty_all_lower)
+
+    assert db.email_exists('fuser@school.edu')
+    assert db.email_exists('FUSER@school.edu')
+
+    with pytest.raises(DatabaseException):
+        db.insert_faculty(faculty_upper_username)
+
+    assert db.get_username_from_email('fUsEr@school.edu') == 'fuser'
+
+
 def test_byte_counts(db):
     byte_counts = {
         'first/path': 100,


### PR DESCRIPTION
Checks for duplicate email addresses in the database are now done in a
case-insensitive manner, though the cases of the characters in the originally
added email address are preserved in case the email server handles the username
portion of the email address in a case-sensitive manner.

Additionally, it used to be the case that a student email address was rejected if
its username portion was not also a valid Linux username. This is no longer the
case, since the string is converted to an appropriate Linux username when creating
the user.