### PR TITLE
pull docker image outside captured command

### DIFF
--- a/git-keeper-server/gkeepserver/submission.py
+++ b/git-keeper-server/gkeepserver/submission.py
@@ -138,6 +138,11 @@ class Submission:
         try:
             test_env = TestEnv(self.test_env_path)
             if test_env.type == TestEnvType.DOCKER:
+                # Run a docker pull on the image here so that the output
+                # is not captured in the email.  If the container image is
+                # already on the server, this will return quickly
+                pull_cmd = ['docker', 'pull', test_env.image]
+                run_command(pull_cmd)
                 cmd = self._make_docker_command(temp_path, assignment_name,
                                                 test_env.image)
             elif test_env.type == TestEnvType.FIREJAIL:


### PR DESCRIPTION

Run a `docker pull` command outside the `run_action.sh`.  This ensures that the output of pulling the Docker image is not included in the student email.  NOTE:  If the image already exists on the server, the `docker pull` command completes quickly.