### PR TITLE
Do not info scan after testing faculty submissions

### DIFF
--- a/git-keeper-server/gkeepserver/submission.py
+++ b/git-keeper-server/gkeepserver/submission.py
@@ -35,6 +35,7 @@ from gkeepcore.test_env_yaml import TestEnv, TestEnvType
 from gkeepcore.system_commands import cp, sudo_chown, rm, chmod, mv
 from gkeepcore.shell_command import run_command
 from gkeepserver.email_sender_thread import email_sender
+from gkeepserver.info_update_thread import info_updater
 from gkeepserver.reports import reports_clone
 from gkeepserver.server_configuration import config
 from gkeepserver.server_email import Email
@@ -165,6 +166,10 @@ class Submission:
 
             if self.student.username != faculty_username:
                 self._add_report(body)
+                info_updater.enqueue_submission_scan(self.faculty_username,
+                                                     self.class_name,
+                                                     self.assignment_name,
+                                                     self.student.username)
 
         except Exception as e:
             report_failure(assignment_name, self.student,

--- a/git-keeper-server/gkeepserver/submission_test_thread.py
+++ b/git-keeper-server/gkeepserver/submission_test_thread.py
@@ -24,7 +24,6 @@ New submissions are pulled from the global new_submission_queue.
 from queue import Empty
 from threading import Thread
 from gkeepserver.gkeepd_logger import gkeepd_logger as logger
-from gkeepserver.info_update_thread import info_updater
 from gkeepserver.new_submission_queue import new_submission_queue
 
 
@@ -70,12 +69,6 @@ class SubmissionTestThread(Thread):
                     submission = new_submission_queue.get(block=True,
                                                           timeout=0.1)
                     submission.run_tests()
-
-                    scan_args = (submission.faculty_username,
-                                 submission.class_name,
-                                 submission.assignment_name,
-                                 submission.student.username)
-                    info_updater.enqueue_submission_scan(*scan_args)
 
             # get() raises Empty when there is nothing in the queue after
             # timeout seconds


### PR DESCRIPTION
Trying to do an info scan after a facutly submission raised an error
which was benign but confusing.