### PR TITLE
Allow gkeep test to use a path for assignment name

### DIFF
--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -546,8 +546,7 @@ def take_action(parsed_args):
     elif action_name == 'admin_demote':
         admin_demote(parsed_args.email_address)
     elif action_name == 'test':
-        test_solution(class_name, parsed_args.assignment_name,
-                      parsed_args.solution_path)
+        test_solution(class_name, assignment_name, parsed_args.solution_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was already the behavior for all the other gkeep actions, now
gkeep test is consistent.