### PR TITLE
Upgrade test env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argcomplete==1.9.3
-cryptography==2.5
+cryptography==3.3.2
 paramiko==2.10.1
 pytest==5.3.5
 python-vagrant==0.5.15

--- a/tests/acceptance/gkclient_base/Vagrantfile
+++ b/tests/acceptance/gkclient_base/Vagrantfile
@@ -15,7 +15,7 @@
 
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/bionic64"
+    config.vm.box = "ubuntu/focal64"
     config.vm.provision "shell", inline:<<-SCRIPT
         useradd -ms /bin/bash keeper
         usermod -aG keeper keeper
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
         apt-get update && apt-get install -y python3-pip libssl-dev git
         apt-get clean
         sudo -H pip3 install -U pip setuptools
-        pip3 install cryptography==2.5
+        pip3 install cryptography==3.3.2
     SCRIPT
     config.vm.provision "file", source:"../ssh_keys", destination:"/home/vagrant/ssh_keys"
     config.vm.provision "shell", inline:<<-SCRIPT

--- a/tests/acceptance/gkserver_base/Vagrantfile
+++ b/tests/acceptance/gkserver_base/Vagrantfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/bionic64"
+    config.vm.box = "ubuntu/focal64"
     config.vm.provision "shell", inline:<<-SCRIPT
         useradd -ms /bin/bash keeper
         usermod -aG keeper keeper

--- a/tests/acceptance/vm_scripts/no_email_to.py
+++ b/tests/acceptance/vm_scripts/no_email_to.py
@@ -20,7 +20,7 @@ import sys
 
 @polling
 def no_email_to(to):
-    if len(glob.glob('/email/{}_*.txt'.format(to))) is 0:
+    if len(glob.glob('/email/{}_*.txt'.format(to))) == 0:
         return True
     return False
 


### PR DESCRIPTION
Move to `ubuntu/focal64` for the test environment.  This provides Python 3.8.10, which allows us to use cryptography 3.3.2.

