### PR TITLE
Change command to verify docker image

### DIFF
--- a/git-keeper-core/gkeepcore/test_env_yaml.py
+++ b/git-keeper-core/gkeepcore/test_env_yaml.py
@@ -201,7 +201,7 @@ def verify_docker_image(image):
           this should only be run on the server.
     """
     # This command taken from https://github.com/distribution/distribution/issues/2412
-    cmd = ['docker', 'buildx', 'imagetools', 'inspect', image]
+    cmd = ['docker', 'manifest', 'inspect', image]
     try:
         run_command(cmd)
     except CommandError:


### PR DESCRIPTION
docker manifest is now used to verify that a docker image exists rather
than docker buildx. The manifest command is built in to docker, while
buildx requires a plugin.