### PR TITLE
Ask for confirmation before gkeep trigger

### DIFF
--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -531,7 +531,7 @@ def take_action(parsed_args):
                   parsed_args.json)
     elif action_name == 'trigger':
         trigger_tests(class_name, assignment_name,
-                      parsed_args.student_usernames)
+                      parsed_args.student_usernames, parsed_args.yes)
     elif action_name == 'passwd':
         reset_password(parsed_args.username)
     elif action_name == 'config':

--- a/git-keeper-client/gkeepclient/server_actions.py
+++ b/git-keeper-client/gkeepclient/server_actions.py
@@ -469,7 +469,7 @@ def publish_assignment(class_name: str, assignment_name: str):
 @assignment_exists
 @assignment_not_disabled
 def trigger_tests(class_name: str, assignment_name: str,
-                  student_usernames: list, response_timeout=20):
+                  student_usernames: list, yes: bool, response_timeout=20):
     """
     Trigger tests to be run on the server.
 
@@ -480,6 +480,7 @@ def trigger_tests(class_name: str, assignment_name: str,
     :param assignment_name: name of the assignment
     :param student_usernames: list of student usernames for whom tests should
     be run, or an empty list for all students
+    :param yes: if True, will automatically answer yes to confirmation prompts
     :param response_timeout: seconds to wait for server response
     """
 
@@ -506,7 +507,14 @@ def trigger_tests(class_name: str, assignment_name: str,
                 error = ('No student {0} in {1}'.format(username, class_name))
                 raise GkeepException(error)
 
-    print('Triggering tests for', assignment_name, 'in class', class_name)
+    print('Triggering tests for', assignment_name, 'in class', class_name,
+          'for the following students:')
+
+    for username in student_usernames:
+        print(username)
+
+    if not yes and not confirmation('Proceed?', 'y'):
+        raise GkeepException('Aborting')
 
     payload = '{0} {1}'.format(class_name, assignment_name)
 

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -290,15 +290,15 @@ class ClientCheckKeywords:
 
     def gkeep_trigger_succeeds(self, faculty, course_name, assignment_name, student_name=None):
         if student_name is None:
-            client_control.run(faculty, 'gkeep trigger {} {}'.format(course_name, assignment_name))
+            client_control.run(faculty, 'gkeep -y trigger {} {}'.format(course_name, assignment_name))
         else:
-            client_control.run(faculty, 'gkeep trigger {} {} {}'.format(course_name, assignment_name, student_name))
+            client_control.run(faculty, 'gkeep -y trigger {} {} {}'.format(course_name, assignment_name, student_name))
 
     def gkeep_trigger_fails(self, faculty, course_name, assignment_name, student_name=None):
         if student_name is None:
-            cmd = 'gkeep trigger {} {}'.format(course_name, assignment_name)
+            cmd = 'gkeep -y trigger {} {}'.format(course_name, assignment_name)
         else:
-            cmd = 'gkeep trigger {} {} {}'.format(course_name, assignment_name, student_name)
+            cmd = 'gkeep -y trigger {} {} {}'.format(course_name, assignment_name, student_name)
 
         try:
             client_control.run(faculty, cmd)


### PR DESCRIPTION
Accidentally leaving off a username when running gkeep trigger would
cause every student in a class to receive a test result email, which
can lead to confusion. Now gkeep trigger asks for a confirmation before
proceeding.