### PR TITLE
remove line that upgrades pip

### DIFF
--- a/tests/acceptance/gkclient_base/Vagrantfile
+++ b/tests/acceptance/gkclient_base/Vagrantfile
@@ -24,7 +24,6 @@ Vagrant.configure("2") do |config|
         echo 'keeper:keeper' | chpasswd
         apt-get update && apt-get install -y python3-pip libssl-dev git
         apt-get clean
-        sudo -H pip3 install -U pip setuptools
         pip3 install cryptography==3.3.2
     SCRIPT
     config.vm.provision "file", source:"../ssh_keys", destination:"/home/vagrant/ssh_keys"


### PR DESCRIPTION

`git-keeper-client` is not installed properly if pip is upgrade.  We believe this is because the home directory was set with `sudo -H`.  This upgrade is unnecessary, so we removed it.