### PR TITLE
remove explicit install of cryptography

### DIFF
--- a/tests/acceptance/gkclient_base/Vagrantfile
+++ b/tests/acceptance/gkclient_base/Vagrantfile
@@ -24,7 +24,6 @@ Vagrant.configure("2") do |config|
         echo 'keeper:keeper' | chpasswd
         apt-get update && apt-get install -y python3-pip libssl-dev git
         apt-get clean
-        pip3 install cryptography==3.3.2
     SCRIPT
     config.vm.provision "file", source:"../ssh_keys", destination:"/home/vagrant/ssh_keys"
     config.vm.provision "shell", inline:<<-SCRIPT


### PR DESCRIPTION

`cryptography` is installed by `paramiko`, which is specified in `setup.py`.  Manual install of `cryptography` is not needed.