### PR TITLE
Add newlines to mysmtpd.py email bodies

### DIFF
--- a/tests/acceptance/gkserver_base/mysmtpd.py
+++ b/tests/acceptance/gkserver_base/mysmtpd.py
@@ -90,9 +90,11 @@ class MySMTPD(smtpd.DebuggingServer):
 
             if msg.is_multipart():
                 for payload in msg.get_payload():
-                    f.write(payload.get_payload(decode=True).decode('utf-8'))
+                    text = payload.get_payload(decode=True).decode('utf-8')
+                    f.write(text.rstrip() + '\n\n')
             else:
-                f.write(msg.get_payload(decode=True).decode('utf-8'))
+                text = msg.get_payload(decode=True).decode('utf-8')
+                f.write(text.rstrip() + '\n\n')
 
 
 def main():


### PR DESCRIPTION
The most straightforward way to read emails on gkserver is with cat,
and since some emails do not contain a newline at the end of the email
body it messes with the prompt and makes the email hard to read. For
HTML emails, both the plain text and HTML portions were not delineated
with newlines either. Now there will always be exactly 2 newlines after
the body of each email, both for plain text and HTML portions.