### PR TITLE
Update new user naming policy

### DIFF
--- a/git-keeper-core/gkeepcore/system_commands.py
+++ b/git-keeper-core/gkeepcore/system_commands.py
@@ -21,7 +21,7 @@ Provides functions for system calls and command line filesystem operations.
 import os
 from getpass import getuser
 from grp import getgrgid, getgrnam
-from pwd import getpwuid, getpwnam
+from pwd import getpwuid, getpwnam, getpwall
 from shutil import which
 
 from gkeepcore.path_utils import user_home_dir
@@ -202,6 +202,16 @@ def sudo_set_password(username, password):
 
     cmd = 'echo {0}:{1} | sudo chpasswd'.format(username, password)
     run_command(cmd)
+
+
+def get_all_users():
+    """
+    Return a list of the usernames of all the users on the system.
+
+    :return: list of all usernames
+    """
+
+    return [user[0] for user in getpwall()]
 
 
 def user_exists(user):

--- a/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
@@ -52,9 +52,9 @@ class ServerCheckKeywords:
             pass
 
     def new_account_email_exists(self, username):
-        result = control.run_vm_python_script('keeper', 'email_to.py',
-                                              username, '"New git-keeper account"',
-                                              'Password')
+        result = control.run_vm_python_script('keeper', 'email_any_contains.py',
+                                              '"New git-keeper account"',
+                                              "$'Username: {}\n'".format(username))
         if result != 'True':
             raise GkeepRobotException('No new account email for {}'.format(username))
 
@@ -132,9 +132,11 @@ class ServerCheckKeywords:
                                                                                       body_contains))
 
     def new_account_email_does_not_exist(self, username):
-        result = control.run_vm_python_script('keeper', 'no_email_to.py',
-                                              username)
-        if result != 'True':
+        result = control.run_vm_python_script('keeper', 'email_any_contains.py',
+                                              '"New git-keeper account"',
+                                              "$'Username: {}\n'".format(username))
+
+        if result == 'True':
             raise GkeepRobotException('Email exists to {}'.format(username))
 
     def user_exists_on_server(self, username):

--- a/git-keeper-server/gkeepserver/check_system.py
+++ b/git-keeper-server/gkeepserver/check_system.py
@@ -56,6 +56,7 @@ def check_system():
     """
 
     check_paths_and_permissions()
+    check_dummy_accounts()
     check_faculty()
 
 
@@ -176,3 +177,21 @@ def check_faculty():
 
     elif not db.is_admin(config.admin_username):
         db.set_admin(config.admin_username)
+
+
+def check_dummy_accounts():
+    """
+    If necessary, add dummy accounts in the database for disallowed usernames.
+    """
+
+    dummy_users = [
+        config.keeper_user,
+        config.keeper_group,
+        config.tester_user,
+        config.student_group,
+        config.faculty_group,
+    ]
+
+    for username in dummy_users:
+        if not db.username_exists(username):
+            db.insert_dummy_user(username)

--- a/tests/acceptance/existing_users.robot
+++ b/tests/acceptance/existing_users.robot
@@ -26,38 +26,20 @@ Adding Student Succeeds When Account Exists
     Add Account On Server    student1
     Add To Class CSV    faculty1    cs1    student1
     Gkeep Add Succeeds    faculty1    cs1
-    Class Contains Student    faculty1    cs1    student1
-    New Account Email Does Not Exist    student1
-
-Adding Student Fails When Dot Gitkeeper Exists
-    [Tags]    error
-    Launch Gkeepd And Configure Admin Account on Client
-    Add Faculty and Configure Accounts on Client    faculty1
-    Add Account On Server    student1
-    Make Empty Dot Gitkeeper Directory    student1
-    Add To Class CSV    faculty1    cs1    student1
-    Gkeep Add Fails    faculty1    cs1
-    Class Does Not Contain Student    faculty1    cs1    student1
-    New Account Email Does Not Exist    student1
+    Class Contains Student    faculty1    cs1    student11
+    New Account Email Exists    student11
 
 Adding Faculty Succeeds When Account Exists
     [Tags]    happy_path
     Launch Gkeepd And Configure Admin Account on Client
     Add Account On Server    faculty1
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    New Account Email Does Not Exist    faculty1
-    Create Accounts On Client    faculty1
-    Create Git Config    faculty1
-    Add To Class CSV    faculty1    cs1    student1
-    Gkeep Add Succeeds    faculty1    cs1
-    Class Contains Student    faculty1    cs1    student1
-
-Adding Faculty Fails When Dot Gitkeeper Exists
-    [Tags]    error
-    Launch Gkeepd And Configure Admin Account on Client
-    Add Account On Server    faculty1
-    Make Empty Dot Gitkeeper Directory    faculty1
-    Gkeep Add Faculty Fails    admin_prof    faculty1
+    New Account Email Exists    faculty11
+    Create Accounts On Client    faculty11
+    Create Git Config    faculty11
+    Add To Class CSV    faculty11    cs1    student1
+    Gkeep Add Succeeds    faculty11    cs1
+    Class Contains Student    faculty11    cs1    student1
 
 Faculty Becomes Student
     [Tags]    happy_path

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -85,10 +85,12 @@ Existing Student
     Gkeep Add Succeeds    faculty=faculty1    class_name=cs1
     User Exists On Server    student1
     User Exists On Server    student2
+    User Exists On Server    student21
     New Account Email Exists    student1
-    New Account Email Does Not Exist    to_user=student2
+    New Account Email Exists    student21
+    New Account Email Does Not Exist    student2
     Class Contains Student    faculty1    cs1    student1
-    Class Contains Student    faculty1    cs1    student2
+    Class Contains Student    faculty1    cs1    student21
 
 Call Add Twice
     [Tags]    error
@@ -109,9 +111,20 @@ Malformed CSV
     Gkeep Add Fails    faculty=faculty1    class_name=cs1
 
 Student Named Student
-    [Tags]    error
+    [Tags]    happy_path
     Add To Class CSV    faculty=faculty1    class_name=cs1    username=student
-    Gkeep Add Fails    faculty=faculty1    class_name=cs1
+    Gkeep Add Succeeds    faculty=faculty1    class_name=cs1
+    Class Contains Student    faculty1    cs1    student1
+    User Exists On Server    student1
+    New Account Email Exists    student1
+
+Student Named Tester
+    [Tags]    happy_path
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=tester
+    Gkeep Add Succeeds    faculty=faculty1    class_name=cs1
+    Class Contains Student    faculty1    cs1    tester1
+    User Exists On Server    tester1
+    New Account Email Exists    tester1
 
 Same Class Name From Different Faculty
     [Tags]    happy_path

--- a/tests/acceptance/gkeep_add_faculty.robot
+++ b/tests/acceptance/gkeep_add_faculty.robot
@@ -56,7 +56,7 @@ Different Case Email
 Uppercase Email
     [Tags]    happy_path
     Gkeep Add Faculty Succeeds    admin_prof    FACULTY1    email_domain='SCHOOL.EDU'
-    New Account Email Exists    FACULTY1
+    New Account Email Exists    faculty1
     User Exists On Server    faculty1
 
 Admin Promote And Demote
@@ -81,3 +81,15 @@ Add Faculty With Same Email Username
     [Tags]    happy_path
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
     Gkeep Add Faculty Succeeds    admin_prof    faculty1     email_domain='gitkeeper.edu'
+
+Faculty Named Faculty
+    [Tags]    happy_path
+    Gkeep Add Faculty Succeeds     admin_prof    faculty
+    User Exists On Server    faculty1
+    New Account Email Exists    faculty1
+
+Faculty Named Keeper
+    [Tags]    happy_path
+    Gkeep Add Faculty Succeeds     admin_prof    keeper
+    User Exists On Server    keeper1
+    New Account Email Exists    keeper1

--- a/tests/acceptance/gkeepd_launch.robot
+++ b/tests/acceptance/gkeepd_launch.robot
@@ -42,9 +42,9 @@ Admin Named Faculty
     [Tags]    error
     Add File To Server    keeper    files/admin_named_faculty_server.cfg    server.cfg
     Start gkeepd
-    Gkeepd Is Not Running
-    User Does Not Exist On Server    faculty
-    New Account Email Does Not Exist    faculty
+    Gkeepd Is Running
+    User Exists On Server    faculty1
+    New Account Email Exists    faculty1
 
 Missing server cfg
     [Tags]    error

--- a/tests/acceptance/vm_scripts/email_any_contains.py
+++ b/tests/acceptance/vm_scripts/email_any_contains.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from gkeeprobot.dectorators import polling
+import glob
+import sys
+
+
+@polling
+def check_emails(subject_contains, body_contains):
+    for file in glob.glob('/email/*.txt'):
+        if check_email_contains(file, subject_contains, body_contains):
+            return True
+    return False
+
+
+def check_email_contains(filename, subject_contains, body_contains):
+    with open(filename) as f:
+        from_line = f.readline()
+        subject_line = f.readline()
+        body = f.read()
+
+        if subject_contains not in subject_line:
+            return False
+
+        if body_contains not in body:
+            return False
+
+        return True
+
+
+print(check_emails(sys.argv[1], sys.argv[2]))

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -21,8 +21,8 @@ def test_insert_student(db):
     student1 = Student('one', 'student', 'student1', 'student1@school.edu')
     student2 = Student('two', 'student', 'student2', 'student2@school.edu')
 
-    assert db.insert_student(student1) == student1
-    assert db.insert_student(student2) == student2
+    assert db.insert_student(student1, []) == student1
+    assert db.insert_student(student2, []) == student2
 
     assert db.username_exists('student1')
     assert db.username_exists('student2')
@@ -33,7 +33,7 @@ def test_insert_student(db):
     assert not db.email_exists('student3@school.edu')
 
     with pytest.raises(DatabaseException):
-        db.insert_student(student1)
+        db.insert_student(student1, [])
 
 
 def test_insert_faculty(db):
@@ -42,8 +42,8 @@ def test_insert_faculty(db):
     faculty2 = Faculty('two', 'faculty', 'faculty2', 'faculty2@school.edu',
                        True)
 
-    assert db.insert_faculty(faculty1) == faculty1
-    assert db.insert_faculty(faculty2) == faculty2
+    assert db.insert_faculty(faculty1, []) == faculty1
+    assert db.insert_faculty(faculty2, []) == faculty2
 
     assert db.username_exists('faculty1')
     assert db.username_exists('faculty2')
@@ -64,7 +64,7 @@ def test_insert_faculty(db):
         db.get_faculty_by_email('faculty3@school.edu')
 
     with pytest.raises(DatabaseException):
-        db.insert_faculty(faculty1)
+        db.insert_faculty(faculty1, [])
 
 
 def test_student_username_exists(db):
@@ -72,8 +72,8 @@ def test_student_username_exists(db):
                       False)
     student = Student('last', 'first', 'student1', 'student1@school.edu')
 
-    db.insert_faculty(faculty)
-    db.insert_student(student)
+    db.insert_faculty(faculty, [])
+    db.insert_student(student, [])
 
     assert db.student_username_exists('student1')
     assert not db.student_username_exists('student2')
@@ -82,18 +82,18 @@ def test_student_username_exists(db):
 
 def test_duplicate_email_usernames(db):
     student0 = db.insert_student(Student('last', 'first', 'user',
-                                         'user@schoolzero.edu'))
+                                         'user@schoolzero.edu'), [])
     student1 = db.insert_student(Student('last', 'first', 'user',
-                                         'user@schoolone.edu'))
+                                         'user@schoolone.edu'), [])
     student2 = db.insert_student(Student('last', 'first', 'user',
-                                         'user@schooltwo.edu'))
+                                         'user@schooltwo.edu'), [])
 
     faculty3 = db.insert_faculty(Faculty('last', 'first', 'user',
-                                         'user@schoolthree.edu', False))
+                                         'user@schoolthree.edu', False), [])
     faculty4 = db.insert_faculty(Faculty('last', 'first', 'user',
-                                         'user@schoolfour.edu', False))
+                                         'user@schoolfour.edu', False), [])
     faculty5 = db.insert_faculty(Faculty('last', 'first', 'user',
-                                         'user@schoolfive.edu', False))
+                                         'user@schoolfive.edu', False), [])
 
     for username in ('user', 'user1', 'user2', 'user3', 'user4', 'user5'):
         assert db.username_exists(username)
@@ -120,8 +120,8 @@ def test_get_all_faculty(db):
     faculty2 = Faculty('two', 'faculty', 'faculty2', 'faculty2@school.edu',
                        True)
 
-    db.insert_faculty(faculty1)
-    db.insert_faculty(faculty2)
+    db.insert_faculty(faculty1, [])
+    db.insert_faculty(faculty2, [])
 
     all_faculty = db.get_all_faculty()
 
@@ -149,8 +149,8 @@ def test_admin(db):
     faculty2 = Faculty('last2', 'first2', 'faculty2', 'faculty2@school.edu',
                        False)
 
-    faculty1 = db.insert_faculty(faculty1)
-    faculty2 = db.insert_faculty(faculty2)
+    faculty1 = db.insert_faculty(faculty1, [])
+    faculty2 = db.insert_faculty(faculty2, [])
 
     assert db.is_admin(faculty1.username)
     assert not db.is_admin(faculty2.username)
@@ -179,7 +179,7 @@ def test_admin(db):
 
 def test_classes(db):
     db.insert_faculty(Faculty('one', 'faculty', 'faculty1',
-                              'faculty1@school.edu', False))
+                              'faculty1@school.edu', False), [])
     assert not db.class_exists('class', 'faculty1')
     db.insert_class('class', 'faculty1')
     assert db.class_exists('class', 'faculty1')
@@ -190,7 +190,7 @@ def test_classes(db):
 
     # ensure a second faculty member can create a class with the same name
     db.insert_faculty(Faculty('two', 'faculty', 'faculty2',
-                              'faculty2@school.edu', False))
+                              'faculty2@school.edu', False), [])
     db.insert_class('class', 'faculty2')
     assert db.class_exists('class', 'faculty2')
 
@@ -211,11 +211,11 @@ def test_class_students(db):
     student2 = Student('two', 'student', 'student2', 'student2@school.edu')
 
     db.insert_faculty(Faculty('one', 'faculty', 'faculty1',
-                              'faculty1@school.edu', False))
+                              'faculty1@school.edu', False), [])
     db.insert_class('class', 'faculty1')
 
-    db.insert_student(student1)
-    db.insert_student(student2)
+    db.insert_student(student1, [])
+    db.insert_student(student2, [])
 
     db.add_student_to_class('class', student1, 'faculty1')
     db.add_student_to_class('class', student2, 'faculty1')
@@ -268,11 +268,11 @@ def test_change_student_name(db):
     student2 = Student('two', 'student', 'student2', 'student2@school.edu')
 
     db.insert_faculty(Faculty('one', 'faculty', 'faculty1',
-                              'faculty1@school.edu', False))
+                              'faculty1@school.edu', False), [])
     db.insert_class('class', 'faculty1')
 
-    db.insert_student(student1)
-    db.insert_student(student2)
+    db.insert_student(student1, [])
+    db.insert_student(student2, [])
 
     db.add_student_to_class('class', student1, 'faculty1')
     db.add_student_to_class('class', student2, 'faculty1')
@@ -298,13 +298,13 @@ def test_email_case(db):
     student_all_lower = Student('last', 'first', 'username', 'username@school.edu')
     student_upper_username = Student('last', 'first', 'USERNAME', 'USERNAME@school.edu')
 
-    db.insert_student(student_all_lower)
+    db.insert_student(student_all_lower, [])
 
     assert db.email_exists('username@school.edu')
     assert db.email_exists('USERNAME@school.edu')
 
     with pytest.raises(DatabaseException):
-        db.insert_student(student_upper_username)
+        db.insert_student(student_upper_username, [])
 
     assert db.get_username_from_email('UsErNaMe@school.edu') == 'username'
 
@@ -316,13 +316,13 @@ def test_email_case(db):
     faculty_upper_username = Faculty('last', 'first', 'FUSER',
                                      'FUSER@school.edu', False)
 
-    db.insert_faculty(faculty_all_lower)
+    db.insert_faculty(faculty_all_lower, [])
 
     assert db.email_exists('fuser@school.edu')
     assert db.email_exists('FUSER@school.edu')
 
     with pytest.raises(DatabaseException):
-        db.insert_faculty(faculty_upper_username)
+        db.insert_faculty(faculty_upper_username, [])
 
     assert db.get_username_from_email('fUsEr@school.edu') == 'fuser'
 
@@ -365,8 +365,8 @@ def test_assignment(db):
     faculty2 = Faculty('last2', 'first2', 'faculty2', 'faculty2@school.edu',
                        False)
 
-    db.insert_faculty(faculty1)
-    db.insert_faculty(faculty2)
+    db.insert_faculty(faculty1, [])
+    db.insert_faculty(faculty2, [])
 
     db.insert_class('class1', 'faculty1')
     db.insert_class('class2', 'faculty1')
@@ -427,7 +427,7 @@ def test_assignment(db):
 def test_disable_assignment(db):
     faculty = Faculty('last', 'first', 'faculty', 'faculty@school.edu',
                        False)
-    db.insert_faculty(faculty)
+    db.insert_faculty(faculty, [])
     db.insert_class('class', 'faculty')
 
     db.insert_assignment('class', 'assgn1', 'faculty')
@@ -456,7 +456,7 @@ def test_disable_assignment(db):
 def test_get_class_assignments(db):
     faculty = Faculty('last', 'first', 'faculty', 'faculty@school.edu',
                        False)
-    db.insert_faculty(faculty)
+    db.insert_faculty(faculty, [])
     db.insert_class('class', 'faculty')
 
     db.insert_assignment('class', 'assgn1', 'faculty')
@@ -489,3 +489,49 @@ def test_get_class_assignments(db):
     for assignment in (assgn1, assgn2):
         assert assignment in enabled_assignments
 
+
+def test_insert_dummy_user(db):
+    db.insert_dummy_user('keeper')
+    assert db.email_exists('keeper@DUMMY')
+
+    faculty = Faculty('last', 'first', 'keeper', 'keeper@school.edu', False)
+    faculty = db.insert_faculty(faculty, [])
+
+    assert faculty.username == 'keeper1'
+    assert db.email_exists('keeper@school.edu')
+    assert not db.email_exists('keeper1@school.edu')
+    assert db.get_username_from_email('keeper@school.edu') == 'keeper1'
+
+    faculty_copy = db.get_faculty_by_username('keeper1')
+    assert faculty_copy.email_address == 'keeper@school.edu'
+
+    db.insert_dummy_user('tester')
+    assert db.email_exists('tester@DUMMY')
+
+    student = Student('last', 'first', 'tester', 'tester@school.edu')
+    student = db.insert_student(student, [])
+
+    assert student.username == 'tester1'
+    assert db.email_exists('tester@school.edu')
+    assert not db.email_exists('tester1@school.edu')
+    assert db.get_username_from_email('tester@school.edu') == 'tester1'
+
+
+def test_insert_users_with_existing_users(db):
+    existing_users = ['user']
+
+    faculty = Faculty('last', 'first', 'user', 'user@school.edu', False)
+    faculty = db.insert_faculty(faculty, existing_users)
+
+    assert faculty.username == 'user1'
+
+    student = Student('last', 'first', 'user', 'user@another-school.edu')
+    student = db.insert_student(student, existing_users)
+
+    assert student.username == 'user2'
+
+    faculty_student = Student('last', 'first', 'user', 'user@school.edu')
+    faculty_student = db.insert_student(faculty_student, existing_users,
+                                        user_exists=True)
+
+    assert faculty_student.username == 'user1'


### PR DESCRIPTION
New users will now always get a new account, even if an account exists with
the same username as their email username and the account is not used by
an existing git-keeper user. In the case of username clashes, the new
user's username is modified by appending incrementing positive integers
to the email username until a unique name is found.

Additionally, users may now be added whose email usernames are keeper,
tester, faculty, or student. Dummy accounts are added to the database
to reserve these names.