### PR TITLE
Blacklist the assignment name tests

### DIFF
--- a/git-keeper-core/gkeepcore/valid_names.py
+++ b/git-keeper-core/gkeepcore/valid_names.py
@@ -32,7 +32,7 @@ def validate_assignment_name(assignment_name: str):
 
     :param assignment_name: name of the assignment
     """
-    blacklist = ['all']
+    blacklist = ['all', 'tests']
 
     if assignment_name in blacklist:
         error = ('"{0}" is not an allowed assignment name'

--- a/tests/acceptance/gkeep_upload.robot
+++ b/tests/acceptance/gkeep_upload.robot
@@ -60,3 +60,13 @@ Double Assignment Upload
     Add Assignment to Client  faculty1  good_simple
     Gkeep Upload Succeeds   faculty1   cs1    good_simple
     Gkeep Upload Fails   faculty1   cs1    good_simple
+
+Assignment Named all
+    [Tags]  error
+    Add Assignment to Client  faculty1  all
+    Gkeep Upload Fails  faculty1  cs1  all
+
+Assignment Named tests
+    [Tags]  error
+    Add Assignment to Client  faculty1  tests
+    Gkeep Upload Fails  faculty1  cs1  tests


### PR DESCRIPTION
Since the student's submission repository is cloned into the temporary
directory that contains the tests folder, testing will not work properly
if there is an assignment named 'tests', so 'tests' is no longer a valid
name for an assignment.

Tests were added to ensure upload fails if an assignment is named 'tests'
or 'all'.