### PR TITLE
Fix setting admin with existing user on system

### DIFF
--- a/git-keeper-server/gkeepserver/check_system.py
+++ b/git-keeper-server/gkeepserver/check_system.py
@@ -57,7 +57,7 @@ def check_system():
 
     check_paths_and_permissions()
     check_dummy_accounts()
-    check_faculty()
+    check_admin()
 
 
 def check_paths_and_permissions():
@@ -166,17 +166,29 @@ def write_gitconfig():
     gkeepd_logger.log_info('Created {0}'.format(config.gitconfig_file_path))
 
 
-def check_faculty():
-    """Add any new faculty members."""
+def check_admin():
+    """
+    Check the admin user in the server configuration.
+
+    If no user exists with the admin email address, add a new faculty admin
+    user. If a faculty user exists with the admin email address, promote the
+    user to admin. If a student user exists with the admin email address, make
+    the existing student user a faculty admin user.
+    """
 
     gkeepd_logger.log_debug('Checking faculty')
 
-    if not db.faculty_username_exists(config.admin_username):
+    if not db.email_exists(config.admin_email):
         add_faculty(config.admin_last_name, config.admin_first_name,
                     config.admin_email, admin=True)
-
-    elif not db.is_admin(config.admin_username):
-        db.set_admin(config.admin_username)
+    else:
+        username = db.get_username_from_email(config.admin_email)
+        if not db.faculty_username_exists(username):
+            add_faculty(config.admin_last_name, config.admin_first_name,
+                        config.admin_email, admin=True)
+        elif not db.is_admin(username):
+            gkeepd_logger.log_info('Making user {} an admin'.format(username))
+            db.set_admin(username)
 
 
 def check_dummy_accounts():

--- a/git-keeper-server/gkeepserver/server_configuration.py
+++ b/git-keeper-server/gkeepserver/server_configuration.py
@@ -227,8 +227,6 @@ class ServerConfiguration:
         self.admin_first_name = None
         self.admin_last_name = None
 
-        self.admin_username = None
-
     def _parse_config_file(self):
         # Use a ConfigParser object to parse the configuration file and store
         # the state
@@ -335,7 +333,7 @@ class ServerConfiguration:
             raise ServerConfigurationError(e.message)
 
         try:
-            self.admin_username, _ = self.admin_email.split('@')
+            _, _ = self.admin_email.split('@')
         except ValueError:
             raise ServerConfigurationError('{} is not a valid email address'
                                            .format(self.admin_email))

--- a/tests/acceptance/gkeepd_launch.robot
+++ b/tests/acceptance/gkeepd_launch.robot
@@ -36,6 +36,12 @@ Admin Account Already Exists
     Add File To Server    keeper    files/valid_server.cfg    server.cfg
     Start gkeepd
     New Account Email Does Not Exist    admin_prof
+    New Account Email Exists    admin_prof1
+    User Exists On Server    admin_prof1
+    Gkeepd Is Running
+    # make sure restarting still works, this was broken in v1.0.0
+    Stop Gkeepd
+    Start Gkeepd
     Gkeepd Is Running
 
 Admin Named Faculty


### PR DESCRIPTION
When setting the admin user in server.cfg with an email username that is
the same as an existing username on the system, gkeepd would add a new
admin user with a modified username, but then gkeepd would fail to
restart because it checked for an existing admin user based on the email
username rather than the full email address.