### PR TITLE
Fix email rate limiting

### DIFF
--- a/git-keeper-server/gkeepserver/email_sender_thread.py
+++ b/git-keeper-server/gkeepserver/email_sender_thread.py
@@ -149,7 +149,7 @@ class EmailSenderThread(Thread):
             sleep_time = config.email_interval - elapsed_time
             sleep(sleep_time)
 
-        self._last_send_time = current_time
+        self._last_send_time = time()
 
         try:
             email.send()


### PR DESCRIPTION
Previously rate limiting was only being applied to every other email when sending a batch of emails.