### PR TITLE
Use the ssh:// form for Git clone URLs

### DIFF
--- a/docs/faculty-users.md
+++ b/docs/faculty-users.md
@@ -883,7 +883,7 @@ In addition, you should have an email from `git-keeper` containing:
 
 ```no-highlight
 Clone URL:
-prof1@gkserver:/home/prof1/prof1/cs100f22/hwk_even.git
+ssh://prof1@gkserver/home/prof1/prof1/cs100f22/hwk_even.git
 
 
 hwk_even: Implement a function to determine if a number is even.
@@ -1048,7 +1048,7 @@ Each student will receive an announcement email:
 
 ```no-highlight
 Clone URL:
-alovelace@gkserver:/home/alovelace/prof1/cs100f22/hwk_even.git
+ssh://alovelace@gkserver/home/alovelace/prof1/cs100f22/hwk_even.git
 
 
 hwk_even: Implement a function to determine if a number is even.
@@ -1116,7 +1116,7 @@ And you should have an email containing:
 
 ```no-highlight
 Clone URL:
-prof1@gkserver:/home/prof1/prof1/cs100f22/project1.git
+ssh://prof1@gkserver/home/prof1/prof1/cs100f22/project1.git
 
 Your first project.  See Canvas for details.
 ```
@@ -1245,7 +1245,7 @@ And you should have an email containing:
 
 ```no-highlight
 Clone URL:
-prof1@gkserver:/home/prof1/prof1/cs100f22/project1.git
+ssh://prof1@gkserver/home/prof1/prof1/cs100f22/project1.git
 
 Your first project is to implement a function to validate
 a username.  See Canvas for details.
@@ -1282,7 +1282,7 @@ And you should have an email containing:
 
 ```no-highlight
 Clone URL:
-prof1@gkserver:/home/prof1/prof1/cs100f22/project1.git
+ssh://prof1@gkserver/home/prof1/prof1/cs100f22/project1.git
 
 Your first project is to implement a function to validate
 a username.  See Canvas for details.

--- a/git-keeper-client/gkeepclient/fetch_submissions.py
+++ b/git-keeper-client/gkeepclient/fetch_submissions.py
@@ -29,6 +29,7 @@ from gkeepclient.server_interface import server_interface
 from gkeepclient.server_response_poller import ServerResponsePoller, \
     ServerResponseType
 from gkeepclient.text_ui import confirmation
+from gkeepcore.git_clone_url import git_clone_url
 from gkeepcore.git_commands import is_non_bare_repo, git_head_hash, \
     git_pull, git_clone_remote
 from gkeepcore.gkeep_exception import GkeepException
@@ -160,23 +161,6 @@ def pull_repo_if_updated(local_repo_path, remote_url, remote_head_hash,
         print(str(e))
 
 
-def build_clone_url(path):
-    """
-    Build a git clone URL with the following form:
-
-    ssh://<username>@<hostname>:<port number>/<path>
-
-    The username, hostname, and port number come from the configuration file,
-    which needs to be parsed.
-
-    :param path: path to the repository on the server
-    :return:
-    """
-    return ('ssh://{0}@{1}:{2}/{3}'
-            .format(config.server_username, config.server_host,
-                    config.server_ssh_port, path))
-
-
 def fetch_student_submission(class_name: str, assignment_name: str,
                              assignment_submission_path: str,
                              remote_head_hash: str, remote_repo_path: str,
@@ -203,7 +187,8 @@ def fetch_student_submission(class_name: str, assignment_name: str,
     student_submission_path = os.path.join(assignment_submission_path,
                                            last_first_username)
 
-    remote_git_url = build_clone_url(remote_repo_path)
+    remote_git_url = git_clone_url(config.server_username, config.server_host,
+                                   config.server_ssh_port, remote_repo_path)
 
     # pull if the repo already exists, clone otherwise
     if os.path.isdir(student_submission_path):
@@ -247,7 +232,8 @@ def fetch_assignment_submissions(class_name: str, assignment_name: str,
     remote_reports_path = info.reports_path(class_name, assignment_name)
     remote_reports_hash = info.reports_hash(class_name, assignment_name)
 
-    remote_git_url = build_clone_url(remote_reports_path)
+    remote_git_url = git_clone_url(config.server_username, config.server_host,
+                                   config.server_ssh_port, remote_reports_path)
 
     if os.path.isdir(assignment_reports_path):
         pull_repo_if_updated(assignment_reports_path, remote_git_url,

--- a/git-keeper-client/gkeepclient/test_solution.py
+++ b/git-keeper-client/gkeepclient/test_solution.py
@@ -26,6 +26,7 @@ from gkeepclient.client_function_decorators import config_parsed, \
     server_interface_connected, class_exists, assignment_exists
 from gkeepclient.server_actions import trigger_tests
 from gkeepclient.server_interface import server_interface
+from gkeepcore.git_clone_url import git_clone_url
 from gkeepcore.git_commands import git_clone_remote, git_add_all, git_commit, \
     git_push, git_unstaged_changes_exist
 from gkeepcore.gkeep_exception import GkeepException
@@ -73,8 +74,8 @@ def test_solution(class_name: str, assignment_name: str, solution_path: str):
     remote_repo_path = os.path.join(server_home_dir, server_username,
                                     class_name, assignment_name) + '.git'
 
-    clone_url = '{}@{}:{}'.format(server_username, config.server_host,
-                                  remote_repo_path)
+    clone_url = git_clone_url(server_username, config.server_host,
+                              config.server_ssh_port, remote_repo_path)
 
     git_clone_remote(clone_url, repo_temp_path)
 

--- a/git-keeper-core/gkeepcore/git_clone_url.py
+++ b/git-keeper-core/gkeepcore/git_clone_url.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Provides a function for building a git clone URL."""
+
+
+DEFAULT_SSH_PORT = 22
+
+
+def git_clone_url(username, host, port, path):
+    """
+    Build a git clone URL with the following form:
+
+    ssh://<username>@<host>:<port><path>
+
+    <path> must begin with a forward slash.
+
+    :param username: username of the user on the server
+    :param host: hostname or IP address of the server
+    :param port: port number of the SSH server
+    :param path: absolute path to the repository on the server
+    :return:
+    """
+
+    if str(port) == str(DEFAULT_SSH_PORT):
+        return 'ssh://{0}@{1}{2}'.format(username, host, path)
+    else:
+        return 'ssh://{0}@{1}:{2}{3}'.format(username, host, port, path)

--- a/git-keeper-server/gkeepserver/assignments.py
+++ b/git-keeper-server/gkeepserver/assignments.py
@@ -22,6 +22,7 @@ from tempfile import TemporaryDirectory
 
 from gkeepcore.action_scripts import get_action_script_and_interpreter
 from gkeepcore.assignment_config import AssignmentConfig
+from gkeepcore.git_clone_url import git_clone_url
 from gkeepcore.student import Student
 from pkg_resources import resource_exists, resource_string, ResolutionError, \
     ExtractionError
@@ -440,9 +441,8 @@ def setup_student_assignment(assignment_dir: AssignmentDirectory,
                              assignment_name=assignment_dir.assignment_name))
 
     # build the clone URL for the assignment
-    clone_url = '{0}@{1}:{2}'.format(student.username,
-                                     config.hostname,
-                                     assignment_repo_path)
+    clone_url = git_clone_url(student.username, config.hostname,
+                              config.ssh_port, assignment_repo_path)
 
     # read email.txt to get the customizable part of the email body
     try:

--- a/git-keeper-server/gkeepserver/server_configuration.py
+++ b/git-keeper-server/gkeepserver/server_configuration.py
@@ -215,6 +215,9 @@ class ServerConfiguration:
         self.faculty_group = 'faculty'
         self.student_group = 'student'
 
+        # server
+        self.ssh_port = 22
+
         # email
         self.use_tls = True
         self.email_username = None
@@ -314,6 +317,12 @@ class ServerConfiguration:
             self.hostname = self._parser.get('server', 'hostname')
         except configparser.NoOptionError as e:
             raise ServerConfigurationError(e.message)
+
+        if self._parser.has_option('server', 'ssh_port'):
+            try:
+                self.ssh_port = int(self._parser.get('email', 'ssh_port'))
+            except ValueError:
+                raise ServerConfigurationError('ssh_port must be an integer')
 
     def _set_admin_options(self):
         # set admin-related attributes


### PR DESCRIPTION
Previously, clone URLs in assignment emails were of this form:

    user@host:path

Now the URL is either this:

    ssh://user@host/path

or this if ssh_port is set to something other than 22 in [server] in
server.cfg:

    ssh://user@host:port/path