### PR TITLE
Update test environment and stop quoting robot strings

### DIFF
--- a/git-keeper-robot/gkeeprobot/control/VMControl.py
+++ b/git-keeper-robot/gkeeprobot/control/VMControl.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import shlex
+
 from gkeepcore.system_commands import chmod
-from gkeepcore.shell_command import run_command
 from tempfile import TemporaryDirectory
 
 from gkeeprobot.control.ServerCommunication import ServerCommunication
@@ -37,12 +38,12 @@ class VMControl:
 
     def run_vm_python_script(self, username, script, port, *args):
         base = 'python3 /vagrant/vm_scripts/' + script
-        cmd = ' '.join([base] + list(args))
+        cmd = ' '.join([base] + [shlex.quote(arg) for arg in args])
         return self.run(username, port, cmd).strip()
 
     def run_vm_bash_script(self, username, script, port, *args):
         base = 'source /vagrant/vm_scripts/' + script
-        cmd = ' '.join([base] + list(args))
+        cmd = ' '.join([base] + [shlex.quote(arg) for arg in args])
         return self.run(username, port, cmd).strip()
 
     def run(self, username, port, cmd):

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -333,7 +333,7 @@ class ClientCheckKeywords:
     def verify_submission_count(self, faculty_name, submission_folder, class_name, assignment_name, student_name, submission_count):
         reports_dir = '{}/{}/{}/reports'.format(submission_folder, class_name, assignment_name)
         student_report_dir = reports_dir + '/last_first_{}'.format(student_name)
-        file_count = client_control.run(faculty_name, 'ls {} | wc -l'.format(student_report_dir)).strip()
+        file_count = client_control.run(faculty_name, 'ls {} | grep -v no_submission | wc -l'.format(student_report_dir)).strip()
         if file_count != submission_count:
             raise GkeepRobotException('Expected {} files but found {}'.format(submission_count, file_count))
 

--- a/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
@@ -53,21 +53,21 @@ class ServerCheckKeywords:
 
     def new_account_email_exists(self, username):
         result = control.run_vm_python_script('keeper', 'email_any_contains.py',
-                                              '"New git-keeper account"',
-                                              "$'Username: {}\n'".format(username))
+                                              'New git-keeper account',
+                                              'Username: {}\n'.format(username))
         if result != 'True':
             raise GkeepRobotException('No new account email for {}'.format(username))
 
     def faculty_role_email_exists(self, username):
         result = control.run_vm_python_script('keeper', 'email_to.py',
-                                              username, '"git-keeper faculty account"',
+                                              username, 'git-keeper faculty account',
                                               'faculty account')
         if result != 'True':
             raise GkeepRobotException('No faculty role email for {}'.format(username))
 
     def gkeepd_check_email_exists(self, username):
         result = control.run_vm_python_script('keeper', 'email_to.py',
-                                              username, '"git-keeper test email"',
+                                              username, 'git-keeper test email',
                                               'This is a test email')
         if result != 'True':
             raise GkeepRobotException('No gkeepd check email for {}'.format(username))
@@ -81,7 +81,7 @@ class ServerCheckKeywords:
 
     def new_assignment_email_exists(self, username, course_name, assignment_name):
         # assignment name is in the body of the message
-        subject = '"[{}] New assignment: {}"'.format(course_name, assignment_name)
+        subject = '[{}] New assignment: {}'.format(course_name, assignment_name)
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               username, subject,
                                               assignment_name)
@@ -91,7 +91,7 @@ class ServerCheckKeywords:
 
     def new_assignment_email_does_not_exist(self, username, course_name, assignment_name):
         # assignment name is in the body of the message
-        subject = '"[{}] New assignment: {}"'.format(course_name, assignment_name)
+        subject = '[{}] New assignment: {}'.format(course_name, assignment_name)
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               username, subject,
                                               assignment_name)
@@ -100,16 +100,16 @@ class ServerCheckKeywords:
                                                                                    assignment_name))
 
     def submission_test_results_email_exists(self, username, course_name, assignment_name, body_contains):
-        subject = '"[{}] {} submission test results"'.format(course_name, assignment_name)
+        subject = '[{}] {} submission test results'.format(course_name, assignment_name)
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               username, subject, body_contains)
 
         if result != 'True':
-            raise GkeepRobotException('No submission test result email for {}, {}, {}'.format(username, course_name,
-                                                                                    assignment_name))
+            raise GkeepRobotException('No submission test result email for {}, {}, {}, {}'.format(username, course_name,
+                                                                                    assignment_name, body_contains))
 
     def submission_test_results_email_does_not_exist(self, username, course_name, assignment_name, body_contains):
-        subject = '"[{}] {} submission test results"'.format(course_name, assignment_name)
+        subject = '[{}] {} submission test results'.format(course_name, assignment_name)
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               username, subject, body_contains)
         if result != 'False':
@@ -117,7 +117,7 @@ class ServerCheckKeywords:
                                                                                     assignment_name))
 
     def submission_disabled_email_exists(self, username, course_name, assignment_name, body_contains):
-        subject = '"[{}] Assignment disabled: {}"'.format(course_name, assignment_name)
+        subject = '[{}] Assignment disabled: {}'.format(course_name, assignment_name)
         result = control.run_vm_python_script('keeper', 'email_to.py',
                                               username, subject, body_contains)
 
@@ -126,7 +126,7 @@ class ServerCheckKeywords:
                                                                                               assignment_name))
 
     def verify_submission_test_result_count(self, username, course_name, assignment_name, body_contains, count):
-        subject = '"[{}] {} submission test results"'.format(course_name, assignment_name)
+        subject = '[{}] {} submission test results'.format(course_name, assignment_name)
         result = control.run_vm_python_script('keeper', 'email_to_count.py',
                                               username, subject, body_contains, count)
         if result != 'True':
@@ -142,7 +142,7 @@ class ServerCheckKeywords:
 
     def new_account_email_does_not_exist(self, username):
         result = control.run_vm_python_script('keeper', 'email_any_contains.py',
-                                              '"New git-keeper account"',
+                                              'New git-keeper account',
                                               "$'Username: {}\n'".format(username))
 
         if result == 'True':

--- a/tests/acceptance/assignments/bad_test_config/tests/determine_test_env.py
+++ b/tests/acceptance/assignments/bad_test_config/tests/determine_test_env.py
@@ -1,6 +1,5 @@
-
-proc_data = open('/proc/1/cgroup').read()
-if 'docker' in proc_data:
+import os
+if os.path.isfile('/.dockerenv'):
     print('In Docker')
 else:
     print('On Host')

--- a/tests/acceptance/assignments/bad_type/tests/determine_test_env.py
+++ b/tests/acceptance/assignments/bad_type/tests/determine_test_env.py
@@ -1,6 +1,5 @@
-
-proc_data = open('/proc/1/cgroup').read()
-if 'docker' in proc_data:
+import os
+if os.path.isfile('/.dockerenv'):
     print('In Docker')
 else:
     print('On Host')

--- a/tests/acceptance/assignments/determine_env/tests/action.py
+++ b/tests/acceptance/assignments/determine_env/tests/action.py
@@ -1,8 +1,6 @@
 import os
 
-proc_data = open('/proc/1/cgroup').read()
-
-if 'docker' in proc_data:
+if os.path.isfile('/.dockerenv'):
     print('docker')
 elif os.getcwd() == '/home/tester/tests':
     print('firejail')

--- a/tests/acceptance/assignments/good_docker/tests/determine_test_env.py
+++ b/tests/acceptance/assignments/good_docker/tests/determine_test_env.py
@@ -1,6 +1,5 @@
-
-proc_data = open('/proc/1/cgroup').read()
-if 'docker' in proc_data:
+import os
+if os.path.isfile('/.dockerenv'):
     print('In Docker')
 else:
     print('On Host')

--- a/tests/acceptance/assignments/good_host/correct_solution/determine_test_env.py
+++ b/tests/acceptance/assignments/good_host/correct_solution/determine_test_env.py
@@ -1,6 +1,5 @@
-
-proc_data = open('/proc/1/cgroup').read()
-if 'docker' in proc_data:
+import os
+if os.path.isfile('/.dockerenv'):
     print('In Docker')
 else:
     print('On Host')

--- a/tests/acceptance/assignments/good_no_config/correct_solution/determine_test_env.py
+++ b/tests/acceptance/assignments/good_no_config/correct_solution/determine_test_env.py
@@ -1,6 +1,5 @@
-
-proc_data = open('/proc/1/cgroup').read()
-if 'docker' in proc_data:
+import os
+if os.path.isfile('/.dockerenv'):
     print('In Docker')
 else:
     print('On Host')

--- a/tests/acceptance/email_html.robot
+++ b/tests/acceptance/email_html.robot
@@ -41,21 +41,21 @@ Launch With Cfg And Submit Assignment
 Assignment Html True Server Html False
     [Tags]    happy_path
     Launch With Cfg And Submit Assignment    files/use_html_false_server.cfg    use_html_true
-    Submission Test Results Email Exists    student1    cs1    use_html_true    "<pre>Solution output\n</pre>"
+    Submission Test Results Email Exists    student1    cs1    use_html_true    <pre>Solution\ output\n</pre>
 
 Assignment Html False Server Html True
     [Tags]    happy_path
     Launch With Cfg And Submit Assignment    files/use_html_true_server.cfg    use_html_false
-    Submission Test Results Email Exists    student1    cs1    use_html_false    "Solution output"
-    Submission Test Results Email Does Not Exist    student1    cs1    use_html_false    "<pre>Solution output\n</pre>"
+    Submission Test Results Email Exists    student1    cs1    use_html_false    Solution\ output
+    Submission Test Results Email Does Not Exist    student1    cs1    use_html_false    <pre>Solution\ output\n</pre>
 
 Server Html True
     [Tags]    happy_path
     Launch With Cfg And Submit Assignment    files/use_html_true_server.cfg    good_simple
-    Submission Test Results Email Exists    student1    cs1    good_simple    "<pre>Done\n</pre>"
+    Submission Test Results Email Exists    student1    cs1    good_simple    <pre>Done\n</pre>
 
 Server Html False
     [Tags]    happy_path
     Launch With Cfg And Submit Assignment    files/use_html_false_server.cfg    good_simple
-    Submission Test Results Email Does Not Exist    student1    cs1    good_simple    "<pre>Done\n</pre>"
+    Submission Test Results Email Does Not Exist    student1    cs1    good_simple    <pre>Done\n</pre>
     Submission Test Results Email Exists    student1    cs1    good_simple    Done

--- a/tests/acceptance/gkclient_base/Vagrantfile
+++ b/tests/acceptance/gkclient_base/Vagrantfile
@@ -15,7 +15,7 @@
 
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/focal64"
+    config.vm.box = "ubuntu/jammy64"
     config.vm.provision "shell", inline:<<-SCRIPT
         useradd -ms /bin/bash keeper
         usermod -aG keeper keeper

--- a/tests/acceptance/gkeep_add.robot
+++ b/tests/acceptance/gkeep_add.robot
@@ -166,6 +166,6 @@ Different Case Email Username
 Different Case Email Domain
     [Tags]    error
     Add To Class CSV    faculty=faculty1    class_name=cs1    username=student1
-    Add To Class CSV    faculty=faculty1    class_name=cs1    username=student1    email_domain='SCHOOL.EDU'
+    Add To Class CSV    faculty=faculty1    class_name=cs1    username=student1    email_domain=SCHOOL.EDU
     Gkeep Add Fails    faculty=faculty1    class_name=cs1
     Gkeepd Is Running

--- a/tests/acceptance/gkeep_add_faculty.robot
+++ b/tests/acceptance/gkeep_add_faculty.robot
@@ -35,14 +35,14 @@ Add One Faculty
 Duplicate Faculty
     [Tags]    error
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    Wait For Email      to_user=faculty1    subject_contains="New git-keeper account"    body_contains=Password
+    Wait For Email      faculty1    New\ git-keeper\ account   Password
     Gkeep Add Faculty Fails    admin_prof    faculty1
     Gkeepd Is Running
 
 Add Faculty As Non Admin
     [Tags]    error
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    Wait For Email      to_user=faculty1    subject_contains="New git-keeper account"    body_contains=Password
+    Wait For Email      faculty1    New\ git-keeper\ account    Password
     Create Accounts On Client    faculty1
     Gkeep Add Faculty Fails    faculty1    prof3
     Gkeepd Is Running
@@ -51,11 +51,11 @@ Different Case Email
     [Tags]    error
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
     Gkeep Add Faculty Fails    admin_prof    FaCuLtY1
-    Gkeep Add Faculty Fails    admin_prof    faculty1    email_domain='ScHoOl.EdU'
+    Gkeep Add Faculty Fails    admin_prof    faculty1    email_domain=ScHoOl.EdU
 
 Uppercase Email
     [Tags]    happy_path
-    Gkeep Add Faculty Succeeds    admin_prof    FACULTY1    email_domain='SCHOOL.EDU'
+    Gkeep Add Faculty Succeeds    admin_prof    FACULTY1    email_domain=SCHOOL.EDU
     New Account Email Exists    faculty1
     User Exists On Server    faculty1
 
@@ -80,7 +80,11 @@ Admin Promote And Demote
 Add Faculty With Same Email Username
     [Tags]    happy_path
     Gkeep Add Faculty Succeeds    admin_prof    faculty1
-    Gkeep Add Faculty Succeeds    admin_prof    faculty1     email_domain='gitkeeper.edu'
+    Gkeep Add Faculty Succeeds    admin_prof    faculty1     email_domain=gitkeeper.edu
+    User Exists On Server    faculty1
+    New Account Email Exists    faculty1
+    User Exists On Server    faculty11
+    New Account Email Exists    faculty11
 
 Faculty Named Faculty
     [Tags]    happy_path

--- a/tests/acceptance/gkserver_base/Vagrantfile
+++ b/tests/acceptance/gkserver_base/Vagrantfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/focal64"
+    config.vm.box = "ubuntu/jammy64"
     config.vm.provision "shell", inline:<<-SCRIPT
         useradd -ms /bin/bash keeper
         usermod -aG keeper keeper

--- a/tests/acceptance/resources/setup.robot
+++ b/tests/acceptance/resources/setup.robot
@@ -26,7 +26,7 @@ Add Faculty and Configure Accounts on Client
     [Arguments]    @{faculty_names}
     FOR    ${username}    IN    @{faculty_names}
             Gkeep Add Faculty Succeeds    admin_prof    ${username}
-            Wait For Email    to_user=${username}    subject_contains="New git-keeper account"    body_contains=Password
+            Wait For Email    ${username}    New\ git-keeper\ account    Password
     END
     Create Accounts On Client  @{faculty_names}
     FOR    ${username}    IN    @{faculty_names}
@@ -40,7 +40,7 @@ Launch Gkeepd And Configure Admin Account on Client
     Add File To Server    keeper    ${server_cfg}    server.cfg
     Start gkeepd
     Wait For Gkeepd
-    Wait For Email    to_user=admin_prof    subject_contains="New git-keeper account"    body_contains=Password
+    Wait For Email    admin_prof    New\ git-keeper\ account    Password
     Create Accounts On Client    admin_prof
 
 Establish Course

--- a/tests/acceptance/student_submit.robot
+++ b/tests/acceptance/student_submit.robot
@@ -64,7 +64,7 @@ Bad Action.sh
     Gkeep Publish Succeeds  faculty1    cs1     bad_action
     Clone Assignment  student1  faculty1    cs1     bad_action
     Student Submits    student1    faculty1    cs1    bad_action    correct_solution
-    Email Exists    student1    subject_contains="bad_action: Failed to process submission - contact instructor"    body_contains="instructor"
+    Email Exists    student1    bad_action:\ Failed\ to\ process\ submission\ -\ contact\ instructor    instructor
 
 Duplicate Assignment Name Across Courses Managed
     [Tags]    happy_path
@@ -103,4 +103,4 @@ Global Timeout Catches Infinite Loop
     Gkeep Publish Succeeds  faculty1    cs1     run_py
     Clone Assignment  student1  faculty1    cs1     run_py
     Student Submits    student1    faculty1    cs1    run_py    infinite_loop_submission
-    Submission Test Results Email Exists    student1   cs1   run_py   "Tests timed out"
+    Submission Test Results Email Exists    student1   cs1   run_py   Tests\ timed\ out

--- a/tests/acceptance/test_env.robot
+++ b/tests/acceptance/test_env.robot
@@ -46,42 +46,42 @@ Student Submits to Firejail Assignment
     Add Upload and Publish Assignment  faculty1  cs1  good_firejail
     Clone Assignment  student1  faculty1    cs1     good_firejail
     Student Submits    student1    faculty1    cs1    good_firejail    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_firejail    "|/home/tester/tests|"
+    Submission Test Results Email Exists    student1    cs1    good_firejail    |/home/tester/tests|
 
 Student Submits to Firejail Append Args Assignment
     [Tags]    happy_path
     Add Upload and Publish Assignment  faculty1  cs1  good_firejail_append_args
     Clone Assignment  student1  faculty1    cs1     good_firejail_append_args
     Student Submits    student1    faculty1    cs1    good_firejail_append_args    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_firejail_append_args    "|/home/tester/tests|"
+    Submission Test Results Email Exists    student1    cs1    good_firejail_append_args    |/home/tester/tests|
 
 Firejail Prevents Writing Large File
     [Tags]    happy_path
     Add Upload and Publish Assignment  faculty1  cs1  good_firejail_large_file
     Clone Assignment  student1  faculty1    cs1     good_firejail_large_file
     Student Submits    student1    faculty1    cs1    good_firejail_large_file    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_firejail_large_file    "File too large"
+    Submission Test Results Email Exists    student1    cs1    good_firejail_large_file    File\ too\ large
 
 Student Submits to Docker Assignment
     [Tags]    happy_path
     Add Upload and Publish Assignment  faculty1  cs1  good_docker
     Clone Assignment  student1  faculty1    cs1     good_docker
     Student Submits    student1    faculty1    cs1    good_docker    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_docker    "In Docker"
+    Submission Test Results Email Exists    student1    cs1    good_docker    In\ Docker
 
 Student Submits to No Config Assignment
     [Tags]    happy_path
     Add Upload and Publish Assignment   faculty1    cs1     good_no_config
     Clone Assignment  student1  faculty1    cs1     good_no_config
     Student Submits    student1    faculty1    cs1    good_no_config    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_no_config    "On Host"
+    Submission Test Results Email Exists    student1    cs1    good_no_config    On\ Host
 
 Student Submits to Host Assignment
     [Tags]    happy_path
     Add Upload and Publish Assignment  faculty1    cs1     good_host
     Clone Assignment  student1  faculty1    cs1     good_host
     Student Submits    student1    faculty1    cs1    good_host    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_host    "On Host"
+    Submission Test Results Email Exists    student1    cs1    good_host    On\ Host
 
 Bad Config Format
     [Tags]  Error
@@ -127,7 +127,7 @@ Faculty Updates to Include Docker Before Publish
     Gkeep Publish Succeeds  faculty1    cs1     good_host
     Clone Assignment  student1  faculty1    cs1     good_host
     Student Submits    student1    faculty1    cs1    good_host    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_host    "In Docker"
+    Submission Test Results Email Exists    student1    cs1    good_host    In\ Docker
 
 Faculty Updates to Include Docker After Publish
     [Tags]  happy_path
@@ -136,7 +136,7 @@ Faculty Updates to Include Docker After Publish
     Gkeep Update Succeeds   faculty1    cs1     good_host     config
     Clone Assignment  student1  faculty1    cs1     good_host
     Student Submits    student1    faculty1    cs1    good_host    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_host    "In Docker"
+    Submission Test Results Email Exists    student1    cs1    good_host    In\ Docker
 
 Faculty Updates to Remove Docker Before Publish
     [Tags]    happy_path
@@ -147,7 +147,7 @@ Faculty Updates to Remove Docker Before Publish
     Gkeep Publish Succeeds  faculty1    cs1     good_docker
     Clone Assignment  student1  faculty1    cs1     good_docker
     Student Submits    student1    faculty1    cs1    good_docker    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_docker    "On Host"
+    Submission Test Results Email Exists    student1    cs1    good_docker    On\ Host
 
 Faculty Updates to Remove Docker After Publish
     [Tags]    happy_path
@@ -156,7 +156,7 @@ Faculty Updates to Remove Docker After Publish
     Gkeep Update Succeeds   faculty1    cs1     good_docker     config
     Clone Assignment  student1  faculty1    cs1     good_docker
     Student Submits    student1    faculty1    cs1    good_docker    correct_solution
-    Submission Test Results Email Exists    student1    cs1    good_docker    "On Host"
+    Submission Test Results Email Exists    student1    cs1    good_docker    On\ Host
 
 Update to Bad Config No Image
     [Tags]  Error
@@ -184,11 +184,11 @@ Test Produces Email to Faculty in Docker
     Add Assignment to Client  faculty1  good_docker
     Gkeep Upload Succeeds   faculty1   cs1    good_docker
     Gkeep Test Succeeds    faculty1    cs1    good_docker    good_docker/correct_solution
-    Submission Test Results Email Exists    faculty1    cs1    good_docker    "In Docker"
+    Submission Test Results Email Exists    faculty1    cs1    good_docker    In\ Docker
 
 Assignment Timeout Overrides Server Timeout
     [Tags]  happy_path
     Add Assignment to Client  faculty1  one_second_timeout
     Gkeep Upload Succeeds  faculty1  cs1  one_second_timeout
     Gkeep Test Succeeds  faculty1  cs1  one_second_timeout  one_second_timeout/correct_solution
-    Submission Test Results Email Exists  faculty1  cs1  one_second_timeout  "Tests timed out"
+    Submission Test Results Email Exists  faculty1  cs1  one_second_timeout  Tests\ timed\ out


### PR DESCRIPTION
The testing Vagrant environments for both client and server were updated to use ubuntu/jammy64. This also required a new approach for checking if an assignment's tests are being run within a Docker container. It now checks for the existance of /.dockerenv

The Python code to execute scripts on the VMs did not escape characters in command line arguments. This meant that all strings containing spaces needed to be quoted before passed to the methods that execute the scripts. Now all such strings are escaped using shlex.quote().