### PR TITLE
Use a raw string for regular expression

### DIFF
--- a/git-keeper-core/gkeepcore/log_file.py
+++ b/git-keeper-core/gkeepcore/log_file.py
@@ -57,7 +57,7 @@ class LogEvent:
 
         :param log_line: line from a log file
         """
-        match = re.match('(\d+.\d+) (\w+) (.*)', log_line)
+        match = re.match(r'(\d+.\d+) (\w+) (.*)', log_line)
 
         if match is None:
             error = ('Log line does not look like an event: {0}'


### PR DESCRIPTION
This regex started generating a SyntaxWarning with Python 3.12, which will become a SyntaxError exception in the future.

Fixes issue #307