### PR TITLE
Fix issue caused by Git update

### DIFF
--- a/docs/admin-users.md
+++ b/docs/admin-users.md
@@ -216,3 +216,20 @@ Once the server is running, the admin user can use the
 ```no-highlight
 gkeep add_faculty <last name> <first name> <email address>
 ```
+
+## Additional Notes
+
+Git now has a security measure in place where, by default, a user cannot clone
+a repository that is owned by another user, even with proper read permissions
+in place. In order to function, git-keeper requires the `keeper` user and all
+faculty users to be able to clone repositories owned by other users. Thus
+`gkeepd` adds a system-wide Git configuration to `/etc/gitconfig` which makes
+all Git repositories considered safe:
+
+```no-highlight
+[safe]
+        directory = *
+```
+
+If this setting is changed, `gkeepd` will restore it on startup. Changing this
+setting will break `gkeepd` functionality until it is restarted.

--- a/git-keeper-core/gkeepcore/git_commands.py
+++ b/git-keeper-core/gkeepcore/git_commands.py
@@ -177,6 +177,25 @@ def git_config(repo_path, config_options):
     run_command(cmd)
 
 
+def git_config_system(config_options):
+    """
+    Run a git config command to query or modify the system configuration.
+    Note that this is run using sudo. The command will be of the following
+    form:
+
+        sudo git config --system <config_options>
+
+    :param config_options: an iterable containing the options to pass to git
+      config
+    :return: the output of the command
+    """
+
+    cmd = ['git', 'config', '--system']
+    cmd.extend(config_options)
+
+    return run_command(cmd, sudo=True)
+
+
 def is_non_bare_repo(repo_path):
     """
     Determine if a directory is a non-bare git repository by checking for the

--- a/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 
 from gkeeprobot.control.ClientControl import ClientControl
 from gkeeprobot.control.ServerControl import ServerControl
@@ -34,7 +35,7 @@ class ClientSetupKeywords:
                                           name)
 
     def establish_ssh_keys(self, name):
-        temp_dir_name = client_control.vm_control.temp_dir.name
+        temp_dir_name = os.path.basename(client_control.vm_control.temp_dir.name)
         client_control.run_vm_bash_script('keeper',
                                           'make_ssh_keys.sh',
                                           name,

--- a/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ServerCheckKeywords.py
@@ -160,3 +160,10 @@ class ServerCheckKeywords:
                                               username)
         if result != 'True':
             raise GkeepRobotException('User {} exists but should not'.format(username))
+
+    def git_safe_directory_is_configured(self):
+        result = control.run_vm_python_script('keeper',
+                                              'git_safe_directory_is_configured.py')
+
+        if result != 'True':
+            raise GkeepRobotException('Git system safe.directory not set to *')

--- a/git-keeper-server/gkeepserver/check_system.py
+++ b/git-keeper-server/gkeepserver/check_system.py
@@ -25,8 +25,10 @@ calling check_system()
 """
 import os
 
+from gkeepcore.git_commands import git_config_system
 from gkeepcore.gkeep_exception import GkeepException
 from gkeepcore.path_utils import user_home_dir
+from gkeepcore.shell_command import CommandExitCodeError
 from gkeepcore.system_commands import (CommandError, user_exists, group_exists,
                                        sudo_add_group, mode, chmod,
                                        this_user, this_group, sudo_add_user,
@@ -56,8 +58,29 @@ def check_system():
     """
 
     check_paths_and_permissions()
+    check_system_git_config()
     check_dummy_accounts()
     check_admin()
+
+
+def check_system_git_config():
+    """
+    Check that git's safe.directory configuration option is set to * in the
+    system-wide git configuration file, and set it if it is not.
+    """
+
+    try:
+        config_output_lines = git_config_system(['safe.directory']).split('\n')
+    except CommandExitCodeError:
+        # Non-zero exit code most likely means the system config file does not
+        # yet exist
+        config_output_lines = []
+
+    if '*' not in config_output_lines:
+        log_message = 'Setting git safe.directory to * system-wide'
+        gkeepd_logger.log_info(log_message)
+
+        git_config_system(['--add', 'safe.directory', '*'])
 
 
 def check_paths_and_permissions():

--- a/tests/acceptance/gkeepd_launch.robot
+++ b/tests/acceptance/gkeepd_launch.robot
@@ -29,6 +29,7 @@ Valid Setup
     User Exists On Server    admin_prof
     User Exists On Server   tester
     Gkeepd Is Running
+    Git Safe Directory Is Configured
 
 Admin Account Already Exists
     [Tags]    happy_path

--- a/tests/acceptance/vm_scripts/git_safe_directory_is_configured.py
+++ b/tests/acceptance/vm_scripts/git_safe_directory_is_configured.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Nathan Sommer and Ben Coleman
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from gkeepcore.shell_command import run_command, CommandExitCodeError
+
+try:
+    output = run_command('git config --system safe.directory').strip()
+    print(output == '*')
+except CommandExitCodeError:
+    print(False)

--- a/tests/acceptance/vm_scripts/reset_server.py
+++ b/tests/acceptance/vm_scripts/reset_server.py
@@ -69,7 +69,12 @@ def remove_users():
             run_command('sudo userdel -r {}'.format(user))
 
 
+def remove_system_gitconfig():
+    run_command('sudo rm -f /etc/gitconfig')
+
+
 stop_gkeepd()
 remove_gkeepd_files()
 delete_email()
 remove_users()
+remove_system_gitconfig()


### PR DESCRIPTION
By default, git no longer allows a user to clone or push to a repository owned by a different user, even if file permissions are set up to allow it. This breaks git-keeper functionality. The workaround is to either mark individual directories as safe in a git configuration file, or mark all directories as safe. We have chosen the latter, because we believe that the permissions on a git-keeper server prevent the insecure scenario that led to the change in the first place.

Now gkeepd will check if the system-wide Git configuration marks all directories as safe on startup, and if that is not the case, it adds changes the configuration to mark all directories as safe using the following command, run with sudo:

    git config --system --set safe.directory '*'

The "Valid Setup" test in gkeepd_launch.robot now checks that the configuration option is set appropriately after confirming that gkeepd is running. When the tests reset the server, the file /etc/gitconfig is removed, forcing it to be created again when gkeepd is launched.

A note was added to the admin user documentation about the git configuration.