### PR TITLE
Fix documentation for gkeep paswd

### DIFF
--- a/docs/faculty-users.md
+++ b/docs/faculty-users.md
@@ -317,7 +317,7 @@ If a student forgets their password, the faculty member can reset their
 password using
 
 ```no-highlight
-gkeep reset <username> 
+gkeep passwd <username> 
 ```
 
 ### Sample Password Reset Email


### PR DESCRIPTION
The documentation said that the command to reset a student's password is gkeep reset, rather than gkeep passwd.