### PR TITLE
Respect $XDG_CONFIG_HOME

### DIFF
--- a/docs/faculty-users.md
+++ b/docs/faculty-users.md
@@ -35,7 +35,8 @@ you do not want to clutter your system's Python packages.
 
 ### Configuration
 
-There must be a configuration file at `~/.config/git-keeper/client.cfg`. The
+There must be a configuration file at `~/.config/git-keeper/client.cfg` (or
+`$XDG_CONFIG_HOME/git-keeper/client.cfg` if `$XDG_CONFIG_HOME` is set). The
 easiest way to create this file is to run `gkeep config`, which will prompt you
 for various values and then create the file.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -251,7 +251,8 @@ application. For information about installing the client, see
 ### Client Configuration
 
 The default configuration file path for `gkeep` is
-`~/.config/git-keeper/client.cfg`. This file can be created using the
+`~/.config/git-keeper/client.cfg` (or `$XDG_CONFIG_HOME/git-keeper/client.cfg`
+if `$XDG_CONFIG_HOME` is set). This file can be created using the
 `gkeep config` command, or edited manually. An alternate configuration file
 path may be specified using `--config_file <file path>` or `-f <file path>`.
 

--- a/git-keeper-client/gkeepclient/client_configuration.py
+++ b/git-keeper-client/gkeepclient/client_configuration.py
@@ -99,9 +99,29 @@ class ClientConfiguration:
         self.local_home_dir = os.path.expanduser('~')
         self.local_username = getuser()
 
+        self.config_dir_path = None
         self.config_path = None
 
         self._parsed = False
+
+    def set_config_dir_path(self, config_dir_path):
+        """
+        Set the path to the base config directory. The configuration file will
+        be expected to be in the git-keeper subdirectory within this directory.
+
+        Must be called before parse().
+
+        Raises ClientConfigureError
+
+        :param config_dir_path: path to the config directory
+        """
+
+        if self._parsed:
+            raise ClientConfigurationError('Config dir path cannot be changed ' 
+                                           'after the configuration file is '
+                                           'parsed')
+
+        self.config_dir_path = os.path.join(config_dir_path, 'git-keeper')
 
     def set_config_path(self, config_path):
         """
@@ -115,8 +135,8 @@ class ClientConfiguration:
         """
 
         if self._parsed:
-            raise ClientConfigurationError('Config path must be set '
-                                           'before the configuration file is '
+            raise ClientConfigurationError('Config path cannot be changed '
+                                           'after the configuration file is '
                                            'parsed')
 
         self.config_path = config_path
@@ -141,10 +161,14 @@ class ClientConfiguration:
         if self._parsed:
             raise ClientConfigurationError('parse() may only be called once')
 
+        if self.config_dir_path is None:
+            relative_path = '.config/git-keeper'
+            self.config_dir_path = os.path.join(self.local_home_dir,
+                                                relative_path)
+
         if self.config_path is None:
-            relative_path = '.config/git-keeper/client.cfg'
-            self.config_path = os.path.join(self.local_home_dir,
-                                            relative_path)
+            self.config_path = os.path.join(self.config_dir_path,
+                                            'client.cfg')
 
         if not os.path.isfile(self.config_path):
             error = '{0} does not exist'.format(self.config_path)
@@ -218,7 +242,7 @@ class ClientConfiguration:
     def _set_local_options(self):
         # Initialize all attributes related to the local client machine
         self.submissions_path = None
-        self.templates_path = os.path.expanduser('~/.config/git-keeper/templates')
+        self.templates_path = os.path.join(self.config_dir_path, 'templates')
 
         if 'local' not in self._parser.sections():
             return

--- a/git-keeper-client/gkeepclient/create_config.py
+++ b/git-keeper-client/gkeepclient/create_config.py
@@ -23,15 +23,29 @@ from gkeepclient.text_ui import confirmation
 from gkeepcore.system_commands import mkdir
 
 
-def create_config():
+def create_config(dirpath):
     """
     Prompt the user for configuration parameters and creates client.cfg
     """
-    dirpath = os.path.expanduser("~/.config/git-keeper/")
-    filepath = os.path.join(dirpath, "client.cfg")
-    if not check_config_file(dirpath, filepath):
-        return
+
     print("Configuring gkeep")
+
+    if dirpath is None:
+        dirpath = os.path.expanduser('~/.config/git-keeper')
+
+    filepath = os.path.join(dirpath, "client.cfg")
+
+    print(f"Configuration will be written to {filepath}")
+    print("Set $XDG_CONFIG_HOME to customize the base config directory.")
+
+    if os.path.isfile(filepath):
+        if not confirmation("Configuration file already exists. Overwrite?"):
+            return
+
+    if not os.path.isdir(dirpath):
+        print(f"Creating {dirpath}")
+        mkdir(dirpath)
+
     host_name = input("Server hostname: ")
     username = input("Username: ")
     ssh_port = input("Server SSH port (press enter for port 22): ")
@@ -60,20 +74,3 @@ def create_config():
             config_file.write(file_text)
     else:
         print("No file was written.")
-
-
-def check_config_file(dirpath, filepath):
-    """
-    Check if client.cfg exist
-
-    :param dirpath: path to the directory containing client.cfg
-    :param filepath: path to client.cfg
-    :return: True if we should proceed with writing client.cfg, False otherwise
-    """
-    if not os.path.isdir(dirpath):
-        mkdir(dirpath)
-    if os.path.isfile(filepath):
-        return confirmation("client.cfg already exists. "
-                            "Do you want to overwrite?")
-    else:
-        return True

--- a/git-keeper-client/gkeepclient/gkeep.py
+++ b/git-keeper-client/gkeepclient/gkeep.py
@@ -22,7 +22,7 @@
 Provides the main entry point for the gkeep client. Parses command line
 arguments and calls the appropriate function.
 """
-
+import os
 import sys
 from argparse import ArgumentParser
 
@@ -519,6 +519,12 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    # Allow users to change the configuration directory through
+    # $XDG_CONFIG_HOME
+    xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
+    if xdg_config_home is not None:
+        config.set_config_dir_path(os.path.expanduser(xdg_config_home))
+
     # Parse the args
     parsed_args = parser.parse_args()
 
@@ -594,7 +600,7 @@ def take_action(parsed_args):
     elif action_name == 'passwd':
         reset_password(parsed_args.username)
     elif action_name == 'config':
-        create_config()
+        create_config(config.config_dir_path)
     elif action_name == 'status':
         update_status(class_name, parsed_args.status)
     elif action_name == 'add_faculty':

--- a/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientCheckKeywords.py
@@ -60,6 +60,17 @@ class ClientCheckKeywords:
         except ExitCodeException:
             pass
 
+    def gkeep_check_custom_location_succeeds(self, faculty, location):
+        cmd = 'export XDG_CONFIG_HOME={}; gkeep check'.format(location)
+        output = client_control.run(faculty, cmd)
+
+        expected = location + '/git-keeper/client.cfg'
+
+        if expected not in output:
+            error = 'Expected to see {} in this output:\n{}'.format(expected,
+                                                                    output)
+            raise GkeepRobotException(error)
+
     def gkeep_add_succeeds(self, faculty, class_name):
         cmd = 'gkeep --yes add {} {}.csv'.format(class_name, class_name)
         client_control.run(faculty, cmd)

--- a/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
+++ b/git-keeper-robot/gkeeprobot/keywords/ClientSetupKeywords.py
@@ -74,9 +74,13 @@ class ClientSetupKeywords:
     def make_empty_directory(self, username, directory_name):
         client_control.run(username, 'mkdir -p {}'.format(directory_name))
 
-    def create_gkeep_config_file(self, faculty):
-        client_control.run_vm_bash_script(faculty, 'make_gkeep_config.sh',
-                                          faculty)
+    def create_gkeep_config_file(self, faculty, location=None):
+        if location is None:
+            client_control.run_vm_bash_script(faculty, 'make_gkeep_config.sh',
+                                              faculty)
+        else:
+            client_control.run_vm_bash_script(faculty, 'make_gkeep_config.sh',
+                                              faculty, location)
 
     def run_gkeep_command(self, faculty, *command):
         cmd = 'gkeep ' + ' '.join(command)

--- a/tests/acceptance/gkeep_config.robot
+++ b/tests/acceptance/gkeep_config.robot
@@ -34,3 +34,7 @@ Relative Submission Path Not Allow
 Absoluate Path Accepted
     Add Submissions Folder to Config    faculty1    ~/submissions
     Gkeep Query JSON Produces Results    faculty1    classes    []
+
+Custom Config Path
+    Create Gkeep Config File    faculty1    location=/home/faculty1/custom_config
+    Gkeep Check Custom Location Succeeds    faculty1    /home/faculty1/custom_config

--- a/tests/acceptance/vm_scripts/make_gkeep_config.sh
+++ b/tests/acceptance/vm_scripts/make_gkeep_config.sh
@@ -15,10 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-mkdir -p .config/git-keeper
-cat > .config/git-keeper/client.cfg <<EOL
+# If a location is provided, use that instead of ~/.config
+if [ -z "$2" ]
+then
+  config_dir=".config"
+else
+  config_dir=$2
+fi
+
+mkdir -p $config_dir/git-keeper
+cat > $config_dir/git-keeper/client.cfg <<EOL
 [server]
 host = gkserver
 username = $1
 EOL
+
 exit 0


### PR DESCRIPTION
If a client user has $XDG_CONFIG_HOME set, the configuration directory will be $XDG_CONFIG_HOME/git-keeper, otherwise it will be the default ~/.config/git-keeper. This adheres to the Freedesktop.org basedir standard: https://specifications.freedesktop.org/basedir-spec/latest/

Resolves #314