### PR TITLE
Acceptance testing on Linux

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -17,7 +17,7 @@
 
 
 """
-This script writes a new version number to the version.py files in all three
+This script writes a new version number to the version.py files in all four
 of the main packages.
 
 Before running this script, place the new version number in the file named
@@ -28,7 +28,6 @@ Versioning 2.0:  https://semver.org/
 """
 
 
-import argparse
 import os
 
 from distutils.version import StrictVersion
@@ -40,6 +39,7 @@ package_paths = (
     'git-keeper-client/gkeepclient',
     'git-keeper-core/gkeepcore',
     'git-keeper-server/gkeepserver',
+    'git-keeper-robot/gkeeprobot'
 )
 
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -118,7 +118,7 @@ features, and the tests should pass before new changes are merged.
 
 Our acceptance tests use two virtual machines:
 
-* `gkserver` - a server to run `gkeepd`. 
+* `gkserver` - a server to run `gkeepd`.
 * `gkclient` - a machine where faculty and student actions can be executed.
 
 We use Vangrant(https://www.vagrantup.com/) (backed by VirtualBox) to launch the machines and [Robot Framework](https://robotframework.org/) to write the tests.
@@ -133,7 +133,19 @@ The `gkserver` VM contains a mock email server that saves files to `/email` inst
 
 ### Setup
 
-Before you can run the test, you must build the VirtualBox images:
+Before you can run the tests, you must install Vagrant and VirtualBox and then build the VirtualBox images. On Linux, to install Vagrant and VirtualBox:
+* KVM/libvirt did not work as the provider for Vagrant for the tests
+* The versions of VirtualBox and Vagrant had to match, installed the most recent versions from their websites:
+    * [VirtualBox: 7.2](https://www.virtualbox.org/wiki/Linux_Downloads)
+    * [Vagrant: 2.4.9](https://developer.hashicorp.com/vagrant/install)
+* Add the current user to the `vboxusers` group:  
+  `sudo usermod -aG vboxusers $USER`
+* Disable KVM temporarily for VirtualBox to work (on reboot KVM will be re-enabled):  
+  `sudo modprobe -r kvm_intel`
+* Add the following line to `/etc/vbox/networks.conf` to allow VirtualBox to use the host-only network for the VMs:  
+  `* 20.0.1.0/8`
+
+Then build the VirtualBox images:
 
 * Goto `tests/acceptance/gkserver_base` and run `make_box.sh`.  This will create an image with the basic setup steps complete.  See the `Vagrantfile` in this directory for the steps.
 * Run `vagrant box add --name gkserver gkserver.box`.  This will allow Vagrant to launch the `gkserver` image.  See `tests/acceptance/Vagrantfile`.
@@ -154,7 +166,7 @@ Once you have built `gkserver` and `gkclient`, you can run the tests.  Run `robo
 When you run tests, Robot Framework has two behaviors:
 
 * If `gkserver` and `gkclient` are already up, it will use these machines for testing - and then leave them running when done.  This saves time when you have to run tests multiple times.
-* If `gkserver` and `gkclient` are not running, it will lauch both machines for testing - and then destroy them when done.
+* If `gkserver` and `gkclient` are not running, it will launch both machines for testing - and then destroy them when done.
 
 In order to avoid side effects, Robot Framework will reset `gkserver` and `gkclient` before each test.  See `vmscripts/reset_server.py` and `vmscripts/reset_client.py` to see what is reset.
 

--- a/git-keeper-robot/gkeeprobot/control/ServerCommunication.py
+++ b/git-keeper-robot/gkeeprobot/control/ServerCommunication.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from paramiko import SSHClient, AutoAddPolicy
-import time
 
 class ServerCommunication:
 
@@ -56,5 +55,7 @@ class ServerCommunication:
         self._sftp_client = self._ssh_client.open_sftp()
 
     def close(self):
-        self._sftp_client.close()
-        self._ssh_client.close()
+        if self._sftp_client is not None:
+            self._sftp_client.close()
+        if self._ssh_client is not None:
+            self._ssh_client.close()

--- a/git-keeper-robot/gkeeprobot/control/VMControl.py
+++ b/git-keeper-robot/gkeeprobot/control/VMControl.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import shlex
+import os.path
 
 from gkeepcore.system_commands import chmod
 from tempfile import TemporaryDirectory
@@ -77,7 +78,7 @@ class VMControl:
             chmod('ssh_keys/keeper_rsa.pub', '600')
             return 'ssh_keys/keeper_rsa'
         else:
-            return '{}/{}_rsa'.format(self.temp_dir.name, username)
+            return '{}/{}_rsa'.format(os.path.basename(self.temp_dir.name), username)
 
     def close_user_connections(self, port):
         to_delete = []

--- a/git-keeper-robot/gkeeprobot/version.py
+++ b/git-keeper-robot/gkeeprobot/version.py
@@ -1,0 +1,5 @@
+# This file was generated automatically and should not be edited manually.
+# Instead, edit the VERSION file in the top level directory of the git-keeper
+# project and then run bump_version.py.
+
+__version__ = '1.2.0'

--- a/git-keeper-robot/setup.py
+++ b/git-keeper-robot/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-from gkeepcore.version import __version__
+from gkeeprobot.version import __version__
 
 setup(
     name='git-keeper-robot',
@@ -19,4 +19,5 @@ setup(
         'Topic :: Education'
     ],
     packages=['gkeeprobot'],
+    install_requires=['git-keeper-core=={}'.format(__version__), 'python-vagrant'],
 )

--- a/tests/acceptance/vm_scripts/reset_client.py
+++ b/tests/acceptance/vm_scripts/reset_client.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shutil
 from gkeepcore.shell_command import run_command, CommandError
 
 
@@ -28,7 +29,10 @@ def remove_users():
             except CommandError:
                 pass
 
-            run_command('sudo userdel -r {}'.format(user))
+            try:
+                run_command('sudo userdel -r {}'.format(user))
+            except CommandError:
+                shutil.rmtree('/home/{}'.format(user))
 
 
 remove_users()

--- a/tests/acceptance/vm_scripts/reset_server.py
+++ b/tests/acceptance/vm_scripts/reset_server.py
@@ -16,6 +16,7 @@
 
 from gkeepcore.shell_command import run_command, CommandError
 import os
+import shutil
 
 
 def server_running():
@@ -66,7 +67,10 @@ def remove_users():
             except CommandError:
                 pass
 
-            run_command('sudo userdel -r {}'.format(user))
+            try:
+                run_command('sudo userdel -r {}'.format(user))
+            except CommandError:
+                shutil.rmtree('/home/{}'.format(user))
 
 
 def remove_system_gitconfig():


### PR DESCRIPTION
This fixes several small issues with `gkeeprobot` that prevented it for running on Linux with more modern Python. Includes documentation for getting it to run on Linux as well. 